### PR TITLE
cmd/tier: lint key before claiming success on connect

### DIFF
--- a/cmd/tier/connect.go
+++ b/cmd/tier/connect.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -29,6 +30,11 @@ Stripe API key: `)
 	fmt.Print(strings.Repeat("*", 40))
 
 	if err := setKey(apiKey); err != nil {
+		return err
+	}
+
+	_, err = tc().WhoAmI(context.Background())
+	if err != nil {
 		return err
 	}
 

--- a/pricing/pricing.go
+++ b/pricing/pricing.go
@@ -156,6 +156,23 @@ func (c *Client) FetchFeatures(ctx context.Context, ids ...string) ([]schema.Fea
 	return fps, nil
 }
 
+type UserInfo struct {
+	// TODO: add fields
+}
+
+func (c *Client) WhoAmI(ctx context.Context) (UserInfo, error) {
+	c.init()
+	_, err := c.sc.Account.Get()
+	if err != nil {
+		var e *stripe.Error
+		if errors.As(err, &e) {
+			return UserInfo{}, errors.New(e.Msg)
+		}
+		return UserInfo{}, err
+	}
+	return UserInfo{}, nil
+}
+
 type Stringish interface {
 	string | []byte
 }


### PR DESCRIPTION
This commit changes the connect command to check the user-provided
Stripe API key prior to giving a success message. If the lint fails, it
will display the Stripe error.
