### PR TITLE
cmd/tier: fix tierClient caching

### DIFF
--- a/cmd/tier/tier.go
+++ b/cmd/tier/tier.go
@@ -169,7 +169,8 @@ func tc() *pricing.Client {
 				fmt.Fprintf(stderr, "tier: Please run `tier connect` to connect your Stripe account\n")
 				os.Exit(1)
 			}
-			return &pricing.Client{StripeKey: key}
+			tierClient = &pricing.Client{StripeKey: key}
+			return tierClient
 		}
 		if err != nil {
 			log.Fatalf("tier: %v", err)


### PR DESCRIPTION
This commit fixes a CLI bug where if a pricing.Client could not be
created from environment variables but was created useing the keyring
would not cache the client for future calls, resulting in multiple
requests to the keyring.