### PR TITLE
cmd/tier: replace key store with config.json

### DIFF
--- a/cmd/tier/profile/profile.go
+++ b/cmd/tier/profile/profile.go
@@ -1,0 +1,89 @@
+package profile
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+var ErrProfileNotFound = errors.New("profile not found")
+
+type Profile struct {
+	Redeemed           bool   `json:"redeemed"`
+	AccountID          string `json:"account_id"`
+	DeviceName         string `json:"account_display_name"`
+	LiveAPIKey         string `json:"livemode_key_secret"`
+	LivePublishableKey string `json:"livemode_key_publishable"`
+	TestAPIKey         string `json:"testmode_key_secret"`
+	TestPublishableKey string `json:"testmode_key_publishable"`
+}
+
+type Profiles map[string]*Profile
+
+type Config struct {
+	Profiles Profiles `json:"profiles"`
+}
+
+func Load(name string) (*Profile, error) {
+	c, err := LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+	p := c.Profiles[name]
+	if p == nil {
+		return nil, ErrProfileNotFound
+	}
+	return p, nil
+}
+
+func LoadConfig() (*Config, error) {
+	f, err := open()
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var c *Config
+	if err := json.NewDecoder(f).Decode(&c); err != nil {
+		if err == io.EOF {
+			return &Config{}, nil
+		}
+		return nil, err
+	}
+	return c, nil
+}
+
+func Save(name string, p *Profile) error {
+	c, err := LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	if c.Profiles == nil {
+		c.Profiles = make(Profiles)
+	}
+	c.Profiles[name] = p
+
+	f, err := open()
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return json.NewEncoder(f).Encode(c)
+}
+
+func open() (*os.File, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	dir := filepath.Join(home, ".config", "tier")
+	if err = os.MkdirAll(dir, 0700); err != nil {
+		return nil, err
+	}
+
+	return os.OpenFile(filepath.Join(dir, "config.json"), os.O_CREATE|os.O_RDWR, 0600)
+}

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -1,0 +1,142 @@
+package fetch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/exp/maps"
+)
+
+func Do[R any](ctx context.Context, c *http.Client, method, urlStr string, body any, opts ...any) (R, error) {
+	var zero R
+
+	var isJSON bool
+	var p io.Reader
+	switch v := body.(type) {
+	case io.Reader:
+		p = v
+	case string:
+		p = strings.NewReader(v)
+	default:
+		data, err := json.Marshal(body)
+		if err != nil {
+			return zero, err
+		}
+		p = bytes.NewReader(data)
+		isJSON = true
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, urlStr, p)
+	if err != nil {
+		return zero, err
+	}
+
+	if isJSON {
+		// Set this header now so that below the client's desired
+		// content-type (if any) can clobber the default.
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	for _, opt := range opts {
+		switch v := opt.(type) {
+		case http.Header:
+			maps.Copy(req.Header, v)
+		case *url.Userinfo:
+			pass, _ := v.Password()
+			req.SetBasicAuth(v.Username(), pass)
+		}
+	}
+
+	res, err := c.Do(req)
+	if err != nil {
+		return zero, err
+	}
+
+	if fetchDebug {
+		res.Body = struct {
+			io.Reader
+			io.Closer
+		}{
+			Reader: io.TeeReader(res.Body, os.Stderr),
+			Closer: res.Body,
+		}
+	}
+
+	return interpretDesiredResponse[R](res)
+}
+
+var fetchDebug, _ = strconv.ParseBool(os.Getenv("FETCH_DEBUG"))
+
+func OK[R any, E error](ctx context.Context, c *http.Client, method, urlStr string, body any, opts ...any) (R, error) {
+	var zero R
+	res, err := Do[*http.Response](ctx, c, method, urlStr, body, opts...)
+	if err != nil {
+		return zero, err
+	}
+
+	// TODO(bmizerany): consider taking an option specifying the range of
+	// status codes that result in an error.
+	if res.StatusCode == 200 {
+		return interpretDesiredResponse[R](res)
+	}
+
+	var e E
+	if err := json.NewDecoder(res.Body).Decode(&e); err != nil {
+		return zero, err
+	}
+	return zero, e
+}
+
+type NotFoundError struct {
+	err error
+}
+
+func (e *NotFoundError) Unwrap() error { return e.err }
+func (e *NotFoundError) Error() string { return e.err.Error() }
+
+func interpretDesiredResponse[R any](res *http.Response) (R, error) {
+	t := func(v any) R {
+		return v.(R)
+	}
+
+	var zero R
+
+	switch any(zero).(type) {
+	case *http.Response:
+		// caller is responsible for closing
+		return t(res), nil
+	case *bytes.Buffer:
+		defer res.Body.Close()
+		b := new(bytes.Buffer)
+		_, err := b.ReadFrom(res.Body)
+		return t(b), err
+	case struct{}:
+		res.Body.Close()
+		return zero, nil
+	case string:
+		defer res.Body.Close()
+		var b strings.Builder
+		_, err := io.Copy(&b, res.Body)
+		return t(b.String()), err
+	case []byte:
+		defer res.Body.Close()
+		data, err := io.ReadAll(res.Body)
+		return t(data), err // mimic same behavior as io.ReadAll
+	default:
+		// TODO(bmizerany): check content-type to see if it is safe to
+		// unmarshal from json? not everyone sets the header correctly.
+		var j R
+		defer res.Body.Close()
+		if err := json.NewDecoder(res.Body).Decode(&j); err != nil {
+			return zero, err
+		}
+		return j, nil
+	}
+}

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -1,0 +1,130 @@
+package fetch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"kr.dev/diff"
+	"tier.run/fetch/fetchtest"
+)
+
+func TestFetch(t *testing.T) {
+	// TODO(bmizerany): test body is closed when needed?
+	ctx := context.Background()
+
+	t.Run("string", func(t *testing.T) {
+		want := `Hello.`
+		c := fetchtest.NewTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
+			io.WriteString(w, want) // nolint: errcheck
+		})
+		got, err := Do[string](ctx, c, "GET", "/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		diff.Test(t, t.Errorf, got, want)
+	})
+	t.Run("[]byte", func(t *testing.T) {
+		want := []byte(`Hello.`)
+		c := fetchtest.NewTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Write(want) // nolint: errcheck
+		})
+		got, err := Do[[]byte](ctx, c, "GET", "/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		diff.Test(t, t.Errorf, got, want)
+	})
+	t.Run("some_struct", func(t *testing.T) {
+		out := []byte(`{"name": "world"}`)
+		c := fetchtest.NewTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Write(out) // nolint: errcheck
+		})
+		type hello struct {
+			Name string
+		}
+		got, err := Do[hello](ctx, c, "GET", "/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := hello{"world"}
+		diff.Test(t, t.Errorf, got, want)
+	})
+	t.Run("any", func(t *testing.T) {
+		out := []byte(`{"name": "world"}`)
+		c := fetchtest.NewTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Write(out) // nolint: errcheck
+		})
+		type hello struct {
+			Name string
+		}
+		got, err := Do[hello](ctx, c, "GET", "/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := hello{"world"}
+		diff.Test(t, t.Errorf, got, want)
+	})
+	t.Run("int", func(t *testing.T) {
+		c := fetchtest.NewTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
+			io.WriteString(w, "1") // nolint: errcheck
+		})
+		got, err := Do[int](ctx, c, "GET", "/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := 1
+		diff.Test(t, t.Errorf, got, want)
+	})
+	t.Run("*bytes.Buffer", func(t *testing.T) {
+		c := fetchtest.NewTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
+			io.WriteString(w, "1") // nolint: errcheck
+		})
+		got, err := Do[*bytes.Buffer](ctx, c, "GET", "/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := new(bytes.Buffer)
+		want.WriteString("1") // nolint: errcheck
+		diff.Test(t, t.Errorf, got, want)
+	})
+}
+
+func TestFetchOK(t *testing.T) {
+	ctx := context.Background()
+	t.Run("error_custom", func(t *testing.T) {
+		c := fetchtest.NewTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(400)
+			io.WriteString(w, `{"code": "problem"}`) // nolint: errcheck
+		})
+		_, got := OK[int, TE](ctx, c, "GET", "/", nil)
+		var want TE
+		if !errors.As(got, &want) {
+			t.Errorf("err = %T; want %T", got, want)
+		}
+	})
+	t.Run("error_client", func(t *testing.T) {
+		c := fetchtest.NewTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(400)
+			io.WriteString(w, `notJSON`) // nolint: errcheck
+		})
+
+		_, err := OK[int, TE](ctx, c, "GET", "/", nil)
+		var got *json.SyntaxError
+		if !errors.As(err, &got) {
+			t.Errorf("err = %T; want %T", got, &json.SyntaxError{})
+		}
+	})
+}
+
+type TE struct {
+	Code string
+}
+
+func (e TE) Error() string {
+	return "test error!"
+}

--- a/fetch/fetchtest/fetchtest.go
+++ b/fetch/fetchtest/fetchtest.go
@@ -1,0 +1,75 @@
+package fetchtest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func BaseURL(c *http.Client) string {
+	if tr, ok := c.Transport.(*httptestTransport); ok {
+		return tr.baseURL
+	}
+	return ""
+}
+
+func NewTLSServer(t *testing.T, h http.HandlerFunc) *http.Client {
+	s := httptest.NewTLSServer(h)
+	t.Cleanup(s.Close)
+
+	c := s.Client()
+	c.Transport = &httptestTransport{
+		base:    c.Transport,
+		baseURL: s.URL,
+	}
+	return c
+}
+
+type httptestTransport struct {
+	base    http.RoundTripper
+	baseURL string
+}
+
+func (tr *httptestTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r = r.Clone(r.Context()) // per RoundTrip contract
+	u, err := url.Parse(tr.baseURL)
+	if err != nil {
+		return nil, err
+	}
+	mergeURLs(r.URL, u)
+	return tr.base.RoundTrip(r)
+}
+
+func mergeURLs(dst, src *url.URL) {
+	// TODO(bmizerany): maybe use reflect to copy all public fields?
+	maybeSet(&dst.Scheme, src.Scheme)
+	maybeSet(&dst.Opaque, src.Opaque)
+	maybeSet(&dst.User, src.User)
+	maybeSet(&dst.Host, src.Host)
+	maybeSet(&dst.Path, src.Path)
+	maybeSet(&dst.RawPath, src.RawPath)
+	maybeSet(&dst.ForceQuery, src.ForceQuery)
+	maybeSet(&dst.RawQuery, src.RawQuery)
+	maybeSet(&dst.Fragment, src.Fragment)
+	maybeSet(&dst.RawFragment, src.RawFragment)
+}
+
+// Coalesce returns the first non-zero value in a, if any; otherwise it returns
+// the zero value of T.
+func coalesce[T comparable](a ...T) T {
+	var zero T
+	for _, v := range a {
+		if v != zero {
+			return v
+		}
+	}
+	return zero
+}
+
+// MaybeSet is shorthand for:
+//
+//	v = Coalesce(v, a)
+func maybeSet[T comparable](v *T, a T) {
+	*v = coalesce(*v, a)
+}


### PR DESCRIPTION
This commit changes the tier command to use a new native schema to store
stripe and other provider keys on disk.

Previously, keys were stored in the host OS's key store, however this
requires code signing and other hoops that didn't provide enough ROI, so
we're following the same style as Stripe: store keys with limited
privledge on disk.

The original idea to detect and use Stripe's config.toml means that tier
would start working without any ceremony, leading to confusion or even
errors in production Stripe accounts. Using our own config removes this.

An added advantange to owning our own config is we can use our preffered
encoding (JSON) over TOML.
