### PR TITLE
cmd/tier: add --live flag

### DIFF
--- a/cmd/tier/profile/profile.go
+++ b/cmd/tier/profile/profile.go
@@ -71,7 +71,9 @@ func Save(name string, p *Profile) error {
 	}
 	defer f.Close()
 
-	return json.NewEncoder(f).Encode(c)
+	e := json.NewEncoder(f)
+	e.SetIndent("", "    ")
+	return e.Encode(c)
 }
 
 func open() (*os.File, error) {


### PR DESCRIPTION
This commit adds a global --live flag to the tier command to switch to live mode in stripe.

Also, move envs and flags to same top-level file and clean up a few things.