### PR TITLE
pricing/schema: start Validate with planID check

### DIFF
--- a/cmd/tier/tier.go
+++ b/cmd/tier/tier.go
@@ -38,8 +38,7 @@ var (
 
 // Errors
 var (
-	errUsage      = errors.New("usage: tier [--live] <connect|push|pull|ls> [<args>]")
-	errPushFailed = errors.New("push failed")
+	errUsage = errors.New("usage: tier [--live] <connect|push|pull|ls> [<args>]")
 )
 
 func main() {
@@ -111,10 +110,7 @@ func tier(cmd string, args []string) error {
 				reason,
 			)
 		}); err != nil {
-			if errors.As(err, &pricing.DecodeError{}) {
-				return err
-			}
-			return errPushFailed
+			return err
 		}
 		return nil
 	case "pull":

--- a/pricing/schema/checker.go
+++ b/pricing/schema/checker.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"tailscale.com/util/multierr"
@@ -11,9 +12,13 @@ type Checker struct {
 	errs []error
 }
 
+var (
+	planRegexp = regexp.MustCompile(`^plan:[a-z0-9:]+@[a-z0-9]+$`)
+)
+
 func (c *Checker) Plan(id string) {
-	if !strings.HasPrefix(id, "plan:") {
-		c.errs = append(c.errs, fmt.Errorf("plan ID (%q) must start with 'plan:'", id))
+	if !planRegexp.MatchString(id) {
+		c.errs = append(c.errs, fmt.Errorf("plan ID (%q) must match %q", id, planRegexp.String()))
 	}
 }
 

--- a/pricing/schema/schema.go
+++ b/pricing/schema/schema.go
@@ -153,5 +153,7 @@ type FeaturePlan struct {
 }
 
 func Validate(p *Plan) error {
-	return nil
+	var check Checker
+	check.Plan(p.ID)
+	return check.Err()
 }

--- a/pricing/schema/schema_test.go
+++ b/pricing/schema/schema_test.go
@@ -1,0 +1,45 @@
+package schema
+
+import "testing"
+
+func TestValidatePlanID(t *testing.T) {
+	cases := []struct {
+		planID string
+		valid  bool
+	}{
+		// invalid
+		{"", false},
+		{"x", false},
+		{"plan:", false},
+		{"plan:a", false},
+		{"plan:a@_", false},
+		{"plan:a@1_1", false},
+		{"plan:a@1:1", false},
+		{"plan:a:b@11", true},
+		{"plan:_a:b@11", false},
+		{"plan:a_b:c@11", false},
+		{"flan:a@0", false},
+		{":a@0", false},
+
+		// valid
+		{"plan:a@0", true},
+		{"plan:a@x", true},
+		{"plan:a@11", true},
+		{"plan:a@1a2b3c", true},
+		{"plan:a@a2b3c1", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.planID, func(t *testing.T) {
+			p := &Plan{ID: tc.planID}
+			err := Validate(p)
+			if tc.valid && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !tc.valid && err == nil {
+				t.Errorf("expected error")
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This commit changes tier so that it validates the planID of each plan before being pushed preventing tier planIDs from being converted incorrectly to stripe product IDs.

Fixes #35
Related #16