### PR TITLE
cmd/tier: stop sending RST_STREAM to upstream telemetry server

### DIFF
--- a/cmd/tier/report.go
+++ b/cmd/tier/report.go
@@ -50,7 +50,7 @@ func (r *reporter) send(ctx context.Context, ev *event) {
 	ok := r.g.TryGo(func() error {
 		data, err := json.Marshal(ev)
 		if err != nil {
-			vlogf("report: %v", err)
+			vvlogf("report: %v", err)
 			return nil
 		}
 
@@ -64,7 +64,7 @@ func (r *reporter) send(ctx context.Context, ev *event) {
 			},
 		})
 
-		vlogf("sending event: %v", ev)
+		vvlogf("sending event: %v", ev)
 		req, err := http.NewRequestWithContext(ctx, "POST", "https://tele.tier.run/api/t", bytes.NewReader(data))
 		if err != nil {
 			panic(err)
@@ -77,11 +77,11 @@ func (r *reporter) send(ctx context.Context, ev *event) {
 			return nil
 		}
 		resp.Body.Close()
-		vlogf("sent events: %v", resp.Status)
+		vvlogf("sent events: %v", resp.Status)
 		return nil
 	})
 	if !ok {
-		vlogf("report: event dropped")
+		vvlogf("report: event dropped")
 	}
 }
 

--- a/cmd/tier/tier.go
+++ b/cmd/tier/tier.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"strconv"
 	"text/tabwriter"
 	"time"
 
@@ -298,10 +299,18 @@ func tc() *features.Client {
 	return tierClient
 }
 
-func vlogf(format string, args ...interface{}) {
-	if *flagVerbose {
+var debugLevel, _ = strconv.Atoi(os.Getenv("TIER_DEBUG"))
+
+func vlogf(format string, args ...any) {
+	if *flagVerbose || debugLevel > 0 {
 		fmt.Fprintf(stderr, format, args...)
 		fmt.Fprintln(stderr)
+	}
+}
+
+func vvlogf(format string, args ...any) {
+	if debugLevel > 2 {
+		vlogf(format, args...)
 	}
 }
 


### PR DESCRIPTION
- cmd/tier: add TIER_DEBUG and use with report debugging
- cmd/tier: stop sending RST_STREAM to upstream telemetry server
