### PR TITLE
cmd/tier: add report command

### DIFF
--- a/client/tier/client.go
+++ b/client/tier/client.go
@@ -15,7 +15,8 @@ import (
 
 // Errors
 var (
-	ErrFeatureExists = errors.New("feature already exists")
+	ErrFeatureExists   = errors.New("feature already exists")
+	ErrFeatureNotFound = errors.New("feature not found")
 )
 
 const Inf = 1<<63 - 1
@@ -81,6 +82,9 @@ type Feature struct {
 	// at the end of each billing period based on usage, and at a price
 	// determined by Tiers, Mode, and Aggregate.
 	Tiers []Tier
+
+	// ReportID is the ID for reporting usage to the billing provider.
+	ReportID string
 }
 
 func (f *Feature) ID() string {

--- a/client/tier/client_test.go
+++ b/client/tier/client_test.go
@@ -28,6 +28,7 @@ func TestMain(m *testing.M) {
 
 func newTestClient(t *testing.T) *Client {
 	t.Helper()
+	t.Parallel()
 
 	sc := stroke.Client(t)
 	if sc.Live() {
@@ -49,8 +50,6 @@ func (c *Client) setClock(t *testing.T, now time.Time) *stroke.Clock {
 }
 
 func TestRoundTrip(t *testing.T) {
-	t.Parallel()
-
 	tc := newTestClient(t)
 	ctx := context.Background()
 

--- a/client/tier/schedule_test.go
+++ b/client/tier/schedule_test.go
@@ -2,6 +2,8 @@ package tier
 
 import (
 	"context"
+	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -9,12 +11,14 @@ import (
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"kr.dev/diff"
+	"kr.dev/errorfmt"
 )
 
 // interesting times to be in
 var (
-	t0 = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	t1 = time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC)
+	t0 = time.Date(2020, 1, 0, 0, 0, 0, 0, time.UTC)
+	t1 = time.Date(2020, 2, 0, 0, 0, 0, 0, time.UTC)
+	t2 = time.Date(2020, 3, 0, 0, 0, 0, 0, time.UTC)
 )
 
 var ignoreProviderIDs = diff.OptionList(
@@ -23,6 +27,8 @@ var ignoreProviderIDs = diff.OptionList(
 )
 
 func TestSchedule(t *testing.T) {
+	ciOnly(t)
+
 	c := newTestClient(t)
 	ctx := context.Background()
 
@@ -54,36 +60,61 @@ func TestSchedule(t *testing.T) {
 		t.Helper()
 		t.Logf("subscribing %s to %# v", org, pretty.Formatter(fs))
 		if err := c.SubscribeTo(ctx, org, fs); err != nil {
-			t.Fatal(err)
+			t.Fatalf("%# v", pretty.Formatter(err))
 		}
 	}
 
-	check := func(org string, want Phase) {
+	check := func(org string, want []Phase) {
 		t.Helper()
-		got, err := c.LookupPhases(ctx, "org:example")
+		got, err := c.LookupPhases(ctx, org)
 		if err != nil {
 			t.Fatal(err)
 		}
-		w := []Phase{want}
-		diff.Test(t, t.Errorf, got, w, ignoreProviderIDs)
+		t.Logf("got phases %# v", pretty.Formatter(got))
+		diff.Test(t, t.Errorf, got, want, ignoreProviderIDs)
 	}
 
 	clock := c.setClock(t, t0)
 	sub("org:example", planFree)
-	check("org:example", Phase{
+	check("org:example", []Phase{{
 		Org:       "org:example",
 		Current:   true,
 		Effective: t0,
 		Features:  planFree,
-	})
+	}})
 
 	clock.Advance(t1)
 	sub("org:example", planPro)
-	check("org:example", Phase{
-		Org:       "org:example",
-		Current:   true,
-		Effective: t0, // unchanged by advanced clock
-		Features:  planPro,
+	check("org:example", []Phase{
+		{
+			Org:       "org:example",
+			Current:   false,
+			Effective: t0, // unchanged by advanced clock
+			Features:  planFree,
+		},
+		{
+			Org:       "org:example",
+			Current:   true,
+			Effective: t1, // unchanged by advanced clock
+			Features:  planPro,
+		},
+	})
+
+	// downgrade and check no new phases
+	sub("org:example", planFree)
+	check("org:example", []Phase{
+		{
+			Org:       "org:example",
+			Current:   false,
+			Effective: t0, // unchanged by advanced clock
+			Features:  planFree,
+		},
+		{
+			Org:       "org:example",
+			Current:   true,
+			Effective: t1, // unchanged by advanced clock
+			Features:  planFree,
+		},
 	})
 }
 
@@ -170,7 +201,7 @@ func TestSubscribeToPlan(t *testing.T) {
 	want := []Phase{{
 		Org:       "org:example",
 		Current:   true,
-		Effective: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		Effective: t0,
 		Features:  fs,
 	}}
 
@@ -178,8 +209,6 @@ func TestSubscribeToPlan(t *testing.T) {
 }
 
 func TestDedupCustomer(t *testing.T) {
-	t.Parallel()
-
 	fs := []Feature{{
 		Name:     "feature:x",
 		Plan:     "plan:test@0",
@@ -210,8 +239,6 @@ func TestDedupCustomer(t *testing.T) {
 }
 
 func TestLookupPhases(t *testing.T) {
-	t.Parallel()
-
 	fs := []Feature{{
 		Name:     "feature:x",
 		Plan:     "plan:test@0",
@@ -243,14 +270,12 @@ func TestLookupPhases(t *testing.T) {
 	diff.Test(t, t.Errorf, got, want, ignoreProviderIDs)
 }
 
-func TestLookupLimits(t *testing.T) {
-	t.Parallel()
-
+func TestReportUsage(t *testing.T) {
 	fs := []Feature{
 		{
 			Plan:      "plan:test@0",
 			Name:      "feature:10",
-			Interval:  "@daily",
+			Interval:  "@monthly",
 			Currency:  "usd",
 			Tiers:     []Tier{{Upto: 10}},
 			Mode:      "graduated",
@@ -259,7 +284,7 @@ func TestLookupLimits(t *testing.T) {
 		{
 			Name:      "feature:inf",
 			Plan:      "plan:test@0",
-			Interval:  "@daily",
+			Interval:  "@monthly",
 			Currency:  "usd",
 			Tiers:     []Tier{{Upto: Inf}},
 			Mode:      "graduated",
@@ -268,7 +293,7 @@ func TestLookupLimits(t *testing.T) {
 		{
 			Name:     "feature:lic",
 			Plan:     "plan:test@0",
-			Interval: "@daily",
+			Interval: "@monthly",
 			Currency: "usd",
 		},
 	}
@@ -276,27 +301,77 @@ func TestLookupLimits(t *testing.T) {
 	tc := newTestClient(t)
 	ctx := context.Background()
 	tc.Push(ctx, fs, pushLogger(t))
+	tc.setClock(t, t0)
 
 	if err := tc.SubscribeTo(ctx, "org:example", fs); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := tc.LookupLimits(ctx, "org:example")
+	g, groupCtx := errgroup.WithContext(ctx)
+	report := func(feature string, n int) {
+		g.Go(func() (err error) {
+			defer errorfmt.Handlef("%s: %w", feature, &err)
+			return tc.ReportUsage(groupCtx, "org:example", feature, Report{
+				N:  n,
+				At: t0,
+			})
+		})
+	}
+
+	report("feature:10", 3)
+	report("feature:inf", 9)
+	if err := g.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := tc.LookupUsage(ctx, "org:example")
 	if err != nil {
 		t.Fatal(err)
 	}
-	slices.SortFunc(got, func(a, b Limit) bool {
-		return a.Name < b.Name
+
+	slices.SortFunc(got, func(a, b Usage) bool {
+		return a.Feature < b.Feature
 	})
 
-	// pretty print got
-	t.Logf("got: %# v", pretty.Formatter(got))
-
-	want := []Limit{
-		{Name: "feature:10", Limit: 10},
-		{Name: "feature:inf", Limit: Inf},
-		{Name: "feature:lic", Limit: Inf},
+	want := []Usage{
+		{Feature: "feature:10", Start: t0, End: endOfStripeMonth(t0), Used: 3, Limit: 10},
+		{Feature: "feature:inf", Start: t0, End: endOfStripeMonth(t0), Used: 9, Limit: Inf},
+		{Feature: "feature:lic", Start: t1, End: t2, Used: 1, Limit: Inf},
 	}
 
 	diff.Test(t, t.Errorf, got, want)
+}
+
+func TestReportUsageFeatureNotFound(t *testing.T) {
+	tc := newTestClient(t)
+	ctx := context.Background()
+
+	fs := []Feature{{
+		Name:      "feature:inf",
+		Plan:      "plan:test@0",
+		Interval:  "@monthly",
+		Currency:  "usd",
+		Tiers:     []Tier{{Upto: Inf}},
+		Mode:      "graduated",
+		Aggregate: "sum",
+	}}
+
+	tc.Push(ctx, fs, pushLogger(t))
+	if err := tc.SubscribeTo(ctx, "org:example", fs); err != nil {
+		t.Fatal(err)
+	}
+	got := tc.ReportUsage(ctx, "org:example", "feature:nope", Report{})
+	if !errors.Is(got, ErrFeatureNotFound) {
+		t.Fatalf("got %v, want %v", got, ErrFeatureNotFound)
+	}
+}
+
+func ciOnly(t *testing.T) {
+	if os.Getenv("CI") == "" {
+		t.Skip("not in CI; skipping long test")
+	}
+}
+
+func endOfStripeMonth(t time.Time) time.Time {
+	return t.AddDate(0, 1, 0).Truncate(time.Minute).Add(-5 * time.Minute)
 }

--- a/client/tier/tier_clone.go
+++ b/client/tier/tier_clone.go
@@ -6,6 +6,24 @@
 
 package tier
 
+// Clone makes a deep copy of Tier.
+// The result aliases no memory with the original.
+func (src *Tier) Clone() *Tier {
+	if src == nil {
+		return nil
+	}
+	dst := new(Tier)
+	*dst = *src
+	return dst
+}
+
+// A compilation failure here means this code must be regenerated, with the command at the top of this file.
+var _TierCloneNeedsRegeneration = Tier(struct {
+	Upto  int
+	Price int
+	Base  int
+}{})
+
 // Clone makes a deep copy of Feature.
 // The result aliases no memory with the original.
 func (src *Feature) Clone() *Feature {
@@ -31,22 +49,5 @@ var _FeatureCloneNeedsRegeneration = Feature(struct {
 	Mode       string
 	Aggregate  string
 	Tiers      []Tier
-}{})
-
-// Clone makes a deep copy of Tier.
-// The result aliases no memory with the original.
-func (src *Tier) Clone() *Tier {
-	if src == nil {
-		return nil
-	}
-	dst := new(Tier)
-	*dst = *src
-	return dst
-}
-
-// A compilation failure here means this code must be regenerated, with the command at the top of this file.
-var _TierCloneNeedsRegeneration = Tier(struct {
-	Upto  int
-	Price int
-	Base  int
+	ReportID   string
 }{})

--- a/client/tier/usage.go
+++ b/client/tier/usage.go
@@ -1,0 +1,127 @@
+package tier
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	"golang.org/x/exp/maps"
+	"tailscale.com/logtail/backoff"
+	"tier.run/stripe"
+)
+
+type Report struct {
+	N       int
+	At      time.Time
+	Clobber bool
+}
+
+type Usage struct {
+	Feature string
+	Start   time.Time
+	End     time.Time
+	Used    int
+	Limit   int
+}
+
+func (c *Client) ReportUsage(ctx context.Context, org, feature string, use Report) error {
+	siid, err := c.lookupSubscriptionItemID(ctx, org, scheduleNameTODO, feature)
+	if err != nil {
+		return err
+	}
+
+	var f stripe.Form
+	f.Set("quantity", use.N)
+	f.Set("timestamp", use.At)
+	if use.Clobber {
+		f.Set("action", "set")
+	} else {
+		f.Set("action", "increment")
+	}
+
+	// TODO(bmizerany): take idempotency key from context or use random
+	// string. if in context then upstream client supplied their own.
+	f.SetIdempotencyKey(randomString())
+
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	// TODO(bmizerany): use Dedup here
+	bo := backoff.NewBackoff("ReportUsage", c.Logf, 3*time.Second)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		err := c.Stripe.Do(ctx, "POST", "/v1/subscription_items/"+siid+"/usage_records", f, nil)
+		c.Logf("ReportUsage: %v", err)
+		bo.BackOff(ctx, err)
+		if err == nil {
+			return nil
+		}
+	}
+}
+
+func (c *Client) LookupUsage(ctx context.Context, org string) ([]Usage, error) {
+	cid, err := c.WhoIs(ctx, org)
+	if err != nil {
+		return nil, err
+	}
+
+	var f stripe.Form
+	f.Set("customer", cid)
+	f.Add("expand[]", "data.price.tiers")
+
+	type T struct {
+		stripe.ID
+		Price    stripePrice
+		Period   struct{ Start, End int64 }
+		Quantity int
+	}
+
+	lines, err := stripe.Slurp[T](ctx, c.Stripe, "GET", "/v1/invoices/upcoming/lines", f)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]Usage{}
+	for _, line := range lines {
+		f := stripePriceToFeature(line.Price)
+		if f.Name == "" { // not a Tier price
+			continue
+		}
+		if seen[f.Name].Used <= line.Quantity {
+			seen[f.Name] = Usage{
+				Feature: f.Name,
+				Start:   time.Unix(line.Period.Start, 0),
+				End:     time.Unix(line.Period.End, 0),
+				Used:    line.Quantity,
+				Limit:   f.Limit(),
+			}
+		}
+	}
+	return maps.Values(seen), nil
+}
+
+func (c *Client) lookupSubscriptionItemID(ctx context.Context, org, name, feature string) (string, error) {
+	s, err := c.lookupSubscription(ctx, org, name)
+	if err != nil {
+		return "", err
+	}
+	for _, f := range s.Features {
+		if f.Name == feature {
+			return f.ReportID, nil
+		}
+	}
+	return "", ErrFeatureNotFound
+}
+
+func randomString() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/cmd/tier/help.go
+++ b/cmd/tier/help.go
@@ -24,6 +24,7 @@ The commands are:
 	subscribe  subscribe an org to a pricing plan
 	phases     list scheduled phases for an org
 	limits     list feature limits for an org
+	report     report usage
 	whois      get the Stripe customer ID for an org
 
 The flags are:
@@ -113,7 +114,17 @@ If the --live flag is provided, your accounts live mode will be used.
 
 	tier [--live] limits <org>
 
-Tier limits lists the provided orgs limits per feature subscribed to.
+Tier limits lists the provided orgs limits and usage per feature subscribed to.
+
+If the --live flag is provided, your accounts live mode will be used.
+`,
+	"report": `Usage:
+
+	tier [--live] report <org> <feature> <n>
+
+Tier report reports that n units of feature were used by org to Stripe.
+
+For a report of usage, see the ("tier limits") command.
 
 If the --live flag is provided, your accounts live mode will be used.
 `,

--- a/cmd/tier/report.go
+++ b/cmd/tier/report.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptrace"
-	"time"
 
 	"go4.org/types"
 	"golang.org/x/sync/errgroup"
@@ -54,9 +53,6 @@ func (r *reporter) send(ctx context.Context, ev *event) {
 			vvlogf("report: %v", err)
 			return nil
 		}
-
-		ctx, cancel := context.WithTimeout(ctx, 300*time.Millisecond)
-		defer cancel()
 
 		done := make(chan struct{})
 		ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
+	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11
 	golang.org/x/tools v0.1.12
 	honnef.co/go/tools v0.3.3
 	kr.dev/diff v0.2.1-0.20220605072704-63b4f29d6f39

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 h1:GZokNIeuVkl3aZHJchRrr13WCsols02MLUcz1U9is6M=
+golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/materialize/checker.go
+++ b/materialize/checker.go
@@ -93,7 +93,7 @@ func isAlphaNumeric(s string, extra string) bool {
 		if slices.Contains([]rune(extra), r) {
 			continue
 		}
-		if !(unicode.IsDigit(r) || unicode.IsLetter(r)) {
+		if !unicode.IsDigit(r) && !unicode.IsLetter(r) {
 			return false
 		}
 	}

--- a/stripe/client_test.go
+++ b/stripe/client_test.go
@@ -13,13 +13,14 @@ func newTestClient(t *testing.T, h func(w http.ResponseWriter, r *http.Request))
 	c := &Client{
 		BaseURL:    fetchtest.BaseURL(hc),
 		HTTPClient: hc,
+		Logf:       t.Logf,
 	}
 	return c
 }
 
 func TestSetIdempotencyKey(t *testing.T) {
 	var got string
-	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	c := newTestClient(t, func(_ http.ResponseWriter, r *http.Request) {
 		got = r.Header.Get("Idempotency-Key")
 	})
 

--- a/stripe/dedup.go
+++ b/stripe/dedup.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Dedup(ctx context.Context, key string, logf func(string, ...any), f func(f Form) error) (winner bool, err error) {
-	defer errorfmt.Handlef("stripe: Singleflight(%s): %w", key, &err)
+	defer errorfmt.Handlef("stripe: Dedup(%s): %w", key, &err)
 
 	bo := backoff.NewBackoff("stripe", logf, 5*time.Second)
 	for {

--- a/stripe/list_test.go
+++ b/stripe/list_test.go
@@ -122,6 +122,7 @@ func testList(t *testing.T, in string, wantOffsets, wantIDs []string) {
 		APIKey:     "test",
 		BaseURL:    s.URL,
 		HTTPClient: s.Client(),
+		Logf:       t.Logf,
 	}
 
 	ctx := context.Background()

--- a/trutil/linewriter.go
+++ b/trutil/linewriter.go
@@ -1,0 +1,42 @@
+package trutil
+
+import (
+	"bytes"
+	"strings"
+)
+
+type LineWriter struct {
+	Prefix    string
+	Logf      func(string, ...any)
+	AutoFlush bool // flush after every write if true
+
+	lineBuf strings.Builder
+}
+
+func (lw *LineWriter) Flush() error {
+	lw.Logf("%s%s", lw.Prefix, lw.lineBuf.String())
+	lw.lineBuf.Reset()
+	return nil
+}
+
+var newline = []byte{'\n'}
+
+func (lw *LineWriter) Write(p []byte) (n int, err error) {
+	if lw.AutoFlush {
+		defer lw.Flush()
+	}
+	p0 := p
+	for {
+		before, after, hasNewline := bytes.Cut(p, newline)
+		lw.lineBuf.Write(before)
+		if hasNewline {
+			lw.lineBuf.WriteByte('\n')
+			if err := lw.Flush(); err != nil {
+				return 0, err
+			}
+			p = after
+		} else {
+			return len(p0), nil
+		}
+	}
+}

--- a/trutil/linewriter_test.go
+++ b/trutil/linewriter_test.go
@@ -1,0 +1,56 @@
+package trutil
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"kr.dev/diff"
+)
+
+func TestLineWriter(t *testing.T) {
+	var writes []string
+	lw := &LineWriter{
+		Logf: func(format string, args ...any) {
+			writes = append(writes, fmt.Sprintf(format, args...))
+		},
+	}
+
+	chunks := []string{
+		"hi", "there", "line", "things\n",
+		"are\n",
+		"nice\n",
+		"yo", "helllkjalksjf             askjf", "\n",
+		"", "", "", "\n",
+		"boom", "done.\n",
+		"many\nlines\none\nchunk\nno ",
+		"newline at end of file",
+	}
+
+	for _, chunk := range chunks {
+		io.WriteString(lw, chunk) // nolint: errcheck
+	}
+
+	want := []string{
+		"hitherelinethings\n",
+		"are\n",
+		"nice\n",
+		"yohelllkjalksjf             askjf\n",
+		"\n",
+		"boomdone.\n",
+		"many\n",
+		"lines\n",
+		"one\n",
+		"chunk\n",
+	}
+	diff.Test(t, t.Errorf, writes, want)
+
+	writes = nil
+	want = []string{
+		"no newline at end of file",
+	}
+	if err := lw.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	diff.Test(t, t.Errorf, writes, want)
+}

--- a/values/collection_test.go
+++ b/values/collection_test.go
@@ -10,9 +10,11 @@ func TestCollection(t *testing.T) {
 	var c Collection[string, int]
 	c.Add("a", 1)
 	c.Add("a", 2)
+	c.Add("b", 2)
 
 	want := Collection[string, int]{
 		"a": []int{1, 2},
+		"b": []int{2},
 	}
 
 	diff.Test(t, t.Errorf, c, want)


### PR DESCRIPTION
This commit adds the report command to tier for reporting usage for
metered features.

Also, this fixes an issue with schedules that caused an error after an
attempt to update a schedule that had already been relesed from its
subscription. Now tier will start a new schedule for any existing
subscription managed by tier for a customer (e.g. "org").

This also fixes/updates the stripe client and test package
stripe/stroke.
