### PR TITLE
api: change /v1/subscribe default behavior

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -168,23 +168,6 @@ func httpJSON(w http.ResponseWriter, v any) error {
 	return enc.Encode(v)
 }
 
-func findFeatures(fs []tier.Feature, names []string) []tier.Feature {
-	if len(names) > 1 {
-		panic("feature folding is not implemented")
-	}
-	var out []tier.Feature
-	for _, f := range fs {
-		for _, n := range names {
-			// TODO(bmizerany): support versioned features, which
-			// would include "plans" like ("feature:x@plan:free@0")
-			if f.Plan == n {
-				out = append(out, f)
-			}
-		}
-	}
-	return out
-}
-
 func invalidRequest(reason string) *trweb.HTTPError {
 	return &trweb.HTTPError{
 		Status:  400,


### PR DESCRIPTION
This changes the /v1/subscribe default behavior to match the CLI's
subscribe command. It takes only a single plan, no effective date, and
updates the current phase in a scheudule with the new features in the
provided plan. There remains a path to allow clients to do more advanced
things like specify multi-phase schedules and update-in-place or
attached to the current phase in interesting ways use the Current field
on tier.Phase.
