### PR TITLE
cmd/tier: update --live flag rules

### DIFF
--- a/cmd/tier/cline/cline.go
+++ b/cmd/tier/cline/cline.go
@@ -1,0 +1,224 @@
+package cline
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+
+	"golang.org/x/exp/slices"
+)
+
+var testTier string
+
+func TestMain(m *testing.M, run func()) {
+	if os.Getenv("CLINE_TEST_RUN_MAIN") != "" {
+		run()
+		os.Exit(0)
+	}
+	os.Setenv("CLINE_TEST_RUN_MAIN", "true")
+
+	// The exit code is captured at the end, but defers the os.Exit to this
+	// defer so that all defers that come after this one are run
+	var code int
+	defer func() {
+		os.Exit(code)
+	}()
+
+	testExe, err := os.Executable()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	testTempDir, err := os.MkdirTemp("", "tier-test")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(testTempDir)
+
+	testTier = testTempDir + "/tier"
+
+	// synlink the test executable to the temp dir or copy if the host OS
+	// does not support symlinks.
+	if err := os.Symlink(testExe, testTier); err != nil {
+		// Otherwise, copy the bytes.
+		src, err := os.Open(testExe)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer src.Close()
+
+		dst, err := os.OpenFile(testTier, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o777)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		_, err = io.Copy(dst, src)
+		if closeErr := dst.Close(); err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	code = m.Run()
+	// allow defers to run
+}
+
+var tempDir string
+
+type Data struct {
+	t      *testing.T
+	stdout bytes.Buffer
+	stderr bytes.Buffer
+	env    []string
+	ran    bool
+}
+
+func Test(t *testing.T) *Data {
+	t.Helper()
+
+	if tempDir == "" {
+		var err error
+		tempDir, err = os.MkdirTemp("", "tier-test")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return &Data{
+		t: t,
+	}
+}
+
+func (d *Data) Setenv(name, value string) {
+	d.t.Helper()
+	d.Unsetenv(name)
+	d.env = append(d.env, name+"="+value)
+}
+
+func (d *Data) Unsetenv(name string) {
+	d.t.Helper()
+	if d.env == nil {
+		d.env = slices.Clone(os.Environ())
+	}
+	for i, e := range d.env {
+		if strings.HasPrefix(e, name+"=") {
+			d.env = slices.Delete(d.env, i, i)
+			return
+		}
+	}
+}
+
+func (d *Data) RunFail(args ...string) {
+	d.t.Helper()
+	if status := d.doRun(args...); status == nil {
+		d.t.Fatal("succeeded unexpectedly")
+	} else {
+		d.t.Log("failed as expected:", status)
+	}
+}
+
+func (d *Data) Run(args ...string) {
+	d.t.Helper()
+	if err := d.doRun(args...); err != nil {
+		d.t.Fatal(err)
+	}
+}
+
+func (d *Data) doRun(args ...string) error {
+	d.t.Helper()
+	d.stdout.Reset()
+	d.stderr.Reset()
+	cmd := exec.Command(testTier, args...)
+	cmd.Stdout = &d.stdout
+	cmd.Stderr = &d.stderr
+	cmd.Env = d.env
+	status := cmd.Run()
+	if d.stdout.Len() > 0 {
+		d.t.Log("standard output:")
+		d.t.Log(d.stdout.String())
+	}
+	if d.stderr.Len() > 0 {
+		d.t.Log("standard error:")
+		d.t.Log(d.stderr.String())
+	}
+	d.ran = true
+	return status
+}
+
+func (d *Data) GrepStdout(match, msg string) {
+	d.t.Helper()
+	d.doGrep(match, &d.stdout, "output", msg)
+}
+
+func (d *Data) GrepStderr(match, msg string) {
+	d.t.Helper()
+	d.doGrep(match, &d.stderr, "error", msg)
+}
+
+func (d *Data) GrepStdoutNot(match, msg string) {
+	d.t.Helper()
+	d.doGrepNot(match, &d.stdout, "output", msg)
+}
+
+func (d *Data) GrepStderrNot(match, msg string) {
+	d.t.Helper()
+	d.doGrepNot(match, &d.stderr, "error", msg)
+}
+
+func (d *Data) GrepBothNot(match, msg string) {
+	d.t.Helper()
+	if d.doGrepMatch(match, &d.stdout) || d.doGrepMatch(match, &d.stderr) {
+		d.t.Errorf("pattern %q found it standard output or standard error: %s", match, msg)
+	}
+}
+
+func (d *Data) GrepBoth(match, msg string) {
+	d.t.Helper()
+	if !d.doGrepMatch(match, &d.stdout) && !d.doGrepMatch(match, &d.stderr) {
+		d.t.Errorf("pattern %q found it standard output or standard error: %s", match, msg)
+	}
+}
+
+// doGrep looks for a regular expression in a buffer and fails if it
+// is not found. The name argument is the name of the output we are
+// searching, "output" or "error". The msg argument is logged on
+// failure.
+func (d *Data) doGrep(match string, b *bytes.Buffer, name, msg string) {
+	d.t.Helper()
+	if !d.doGrepMatch(match, b) {
+		d.t.Log(msg)
+		d.t.Logf("pattern %q not found in standard %s", match, name)
+		d.t.FailNow()
+	}
+}
+
+func (d *Data) doGrepNot(match string, b *bytes.Buffer, name, msg string) {
+	d.t.Helper()
+	if d.doGrepMatch(match, b) {
+		d.t.Log(msg)
+		d.t.Logf("pattern %q found in standard %s", match, name)
+		d.t.FailNow()
+	}
+}
+
+func (d *Data) doGrepMatch(match string, b *bytes.Buffer) bool {
+	d.t.Helper()
+	if !d.ran {
+		d.t.Fatal("internal testsuite error: grep called before run")
+	}
+	re := regexp.MustCompile(match)
+	for _, ln := range bytes.Split(b.Bytes(), []byte{'\n'}) {
+		if re.Match(ln) {
+			return true
+		}
+	}
+	return false
+
+}

--- a/cmd/tier/connect.go
+++ b/cmd/tier/connect.go
@@ -112,9 +112,6 @@ func fetchProfile(ctx context.Context, pollURL string) (*profile.Profile, error)
 // order. It returns an error if no key is found.
 func getKey() (string, error) {
 	if envAPIKey != "" {
-		if *flagLive {
-			return "", errors.New("cannot use --live with STRIPE_API_KEY set")
-		}
 		return envAPIKey, nil
 	}
 

--- a/cmd/tier/help.go
+++ b/cmd/tier/help.go
@@ -31,7 +31,7 @@ The commands are:
 
 The flags are:
 
-	-l, -live  use live Stripe key (default is false)
+	-live      use live Stripe key (default is false)
 	-v         verbose output
 	-h         show this message
 `)

--- a/cmd/tier/tier.go
+++ b/cmd/tier/tier.go
@@ -363,6 +363,19 @@ func tc() *tier.Client {
 			}
 			os.Exit(1)
 		}
+
+		if stripe.IsLiveKey(key) {
+			if !*flagLive {
+				fmt.Fprintf(stderr, "tier: --live is required if stripe key is a live key\n")
+				os.Exit(1)
+			}
+		} else {
+			if *flagLive {
+				fmt.Fprintf(stderr, "tier: --live provided with test key\n")
+				os.Exit(1)
+			}
+		}
+
 		sc := &stripe.Client{
 			APIKey:    key,
 			KeyPrefix: os.Getenv("TIER_KEY_PREFIX"),

--- a/cmd/tier/tier_test.go
+++ b/cmd/tier/tier_test.go
@@ -1,48 +1,49 @@
 package main
 
 import (
-	"io"
-	"strings"
 	"testing"
+
+	"tier.run/cmd/tier/cline"
+	"tier.run/stripe"
 )
 
-func setStdin(t *testing.T, r io.Reader) {
-	old := stdin
-	stdin = r
-	t.Cleanup(func() {
-		stdin = old
-	})
+func TestMain(m *testing.M) {
+	cline.TestMain(m, main)
 }
 
-func setStdout(t *testing.T, w io.Writer) {
-	old := stdout
-	stdout = w
-	t.Cleanup(func() {
-		stdout = old
-	})
+func testtier(t *testing.T) *cline.Data {
+	t.Helper()
+	t.Log("=== start ===")
+	c, err := stripe.FromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Live() {
+		t.Fatal("STRIPE_API_KEY must be a live key")
+	}
+	return cline.Test(t)
 }
 
-func setStderr(t *testing.T, w io.Writer) {
-	old := stderr
-	stderr = w
-	t.Cleanup(func() {
-		stderr = old
-	})
+func TestVersion(t *testing.T) {
+	tt := testtier(t)
+	tt.Run("version")
+	tt.GrepStdout(`^\d+\.\d+\.\d+`, "unexpected version format")
 }
 
-func TestBadJSON(t *testing.T) {
-	setStdout(t, panicOnWrite)
-	setStderr(t, panicOnWrite)
-	setStdin(t, strings.NewReader(`{]`))
+func TestLiveFlag(t *testing.T) {
+	tt := testtier(t)
+	tt.Setenv("STRIPE_API_KEY", "sk_test_123")
+	tt.RunFail("--live", "pull")
+	tt.GrepStderr("^tier: --live provided with test key", "unexpected error message")
 
-	// err := tier("push", nil)
-	// if !errors.As(err, &pricing.DecodeError{}) {
-	// t.Fatalf("err = %v, want DecodeError", err)
-	//}
+	tt = testtier(t)
+	tt.Setenv("STRIPE_API_KEY", "sk_live_123")
+	tt.RunFail("--live", "pull") // fails due to invalid key only
+	tt.GrepStderr("stripe:.*Invalid API Key", "unexpected error message")
+	tt.GrepBothNot("--live", "output contains --live flag")
+
+	tt = testtier(t)
+	tt.Setenv("STRIPE_API_KEY", "sk_live_123")
+	tt.RunFail("-l", "pull") // fails due to invalid key only
+	tt.GrepStderr("Usage", "-l did not produce usage")
 }
-
-type pow struct{}
-
-func (w *pow) Write(p []byte) (int, error) { panic("unexpected write") }
-
-var panicOnWrite = &pow{}

--- a/stripe/client.go
+++ b/stripe/client.go
@@ -146,8 +146,12 @@ func FromEnv() (*Client, error) {
 	return &Client{APIKey: key}, nil
 }
 
+func IsLiveKey(key string) bool {
+	return !strings.Contains(key, "_test_")
+}
+
 func (c *Client) Live() bool {
-	return !strings.Contains(c.APIKey, "_test_")
+	return IsLiveKey(c.APIKey)
 }
 
 func (c *Client) client() *http.Client {


### PR DESCRIPTION
The --live flag is now required if key found in the environment is also
a live key; otherwise it is not allowed to be set.

This means the --live flag is now not only a way to specify one wants to
work in live mode, but also a confirmation that live mode is intended if
STRIPE_API_KEY is set with a test mode key.
