### PR TITLE
client: abort subscribe with invalid features

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -184,7 +184,11 @@ func TestAPISubscribe(t *testing.T) {
 		Plans:    []string{"plan:test@0"},
 	})
 
-	sub("org:test", []string{"plan:test@0", "feature:nope@0"}, nil)
+	sub("org:test", []string{"plan:test@0", "feature:nope@0"}, &trweb.HTTPError{
+		Status:  400,
+		Code:    "feature_not_found",
+		Message: "feature not found",
+	})
 }
 
 func TestPhaseBadOrg(t *testing.T) {

--- a/refs/refs.go
+++ b/refs/refs.go
@@ -180,6 +180,14 @@ func MustParseFeaturePlan(s string) FeaturePlan {
 	return fp
 }
 
+func MustParseFeaturePlans(s ...string) []FeaturePlan {
+	fps, err := ParseFeaturePlans(s...)
+	if err != nil {
+		panic(err)
+	}
+	return fps
+}
+
 func ByName(a, b FeaturePlan) bool {
 	return a.name < b.name
 }


### PR DESCRIPTION
Previously, subscribe would fail silently and "successfully" subscribe
an org to only features that were valid, resulting in a seemingly
partial subscription. This changes the subscribe behavior to abort any
call to subscribe with invalid features.

Also clean up someone of the more verbose parts of tests with
abbreviated func names.
