### PR TITLE
cmd/tier: require the explicit intention to use stdin

### DIFF
--- a/cmd/tier/help.go
+++ b/cmd/tier/help.go
@@ -47,10 +47,12 @@ Print the version of the Tier CLI.
 
 	"push": `Usage:
 
-	tier [--live] push <filename>
+	tier [--live] push <filename | - >
 
-Tier push pushes the pricing JSON in the provided filename to Stripe. To learn
-more about how this works, please visit: https://tier.run/docs/cli/push
+Tier push pushes the pricing JSON in the provided filename to Stripe. If the
+filename is ("-") then stdin is read.
+
+To learn more about how this works, please visit: https://tier.run/docs/cli/push
 
 If the --live flag is provided, your accounts live mode will be used.
 `,

--- a/cmd/tier/tier.go
+++ b/cmd/tier/tier.go
@@ -21,6 +21,7 @@ import (
 
 	"go4.org/types"
 	"golang.org/x/exp/slices"
+	"golang.org/x/term"
 	"tier.run/api"
 	"tier.run/api/materialize"
 	"tier.run/client/tier"
@@ -326,7 +327,11 @@ func runTier(cmd string, args []string) (err error) {
 }
 
 func fileOrStdin(fname string) (io.ReadCloser, error) {
-	if fname == "" || fname == "-" {
+	isTerm := term.IsTerminal(int(os.Stdin.Fd()))
+	if isTerm && fname == "" || fname == "-" {
+		return nil, errUsage
+	}
+	if !isTerm {
 		return io.NopCloser(stdin), nil
 	}
 	return os.Open(fname)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/tools v0.1.12
 	honnef.co/go/tools v0.3.3
 	kr.dev/diff v0.3.1-0.20221025214654-4c9427f2d4d4

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,8 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Previously tier push was trying to be smart and read from stdin based on
a handful of heuristics, such as if stdin was a TTY, or if the filename
was the ("-"), etc. This replaces the need for all of that by requiring
the user explicitly initiates the reading of stdin using the special
filename ("-").

This also fixes a bugs with exit codes and help messages.
