### PR TITLE
cmd/tier,control: enforce plan immutability

### DIFF
--- a/api/materialize/views.go
+++ b/api/materialize/views.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	"github.com/tailscale/hujson"
-	"kr.dev/errorfmt"
 	"tier.run/api/apitypes"
 	"tier.run/control"
 	"tier.run/refs"
@@ -19,7 +18,6 @@ func FromPricingHuJSON(data []byte) (fs []control.Feature, err error) {
 	dbg := func(k string) {
 		debug = append(debug, k)
 	}
-	defer errorfmt.Handlef("FromPricingHuJSON: %q: %w", &debug, &err)
 
 	data, err = hujson.Standardize(data)
 	if err != nil {

--- a/cmd/tier/cline/cline.go
+++ b/cmd/tier/cline/cline.go
@@ -180,6 +180,10 @@ func (d *Data) SetStdin(r io.Reader) {
 	d.stdin = r
 }
 
+func (d *Data) SetStdinString(s string) {
+	d.SetStdin(strings.NewReader(s))
+}
+
 // doGrep looks for a regular expression in a buffer and fails if it
 // is not found. The name argument is the name of the output we are
 // searching, "output" or "error". The msg argument is logged on

--- a/cmd/tier/tier.go
+++ b/cmd/tier/tier.go
@@ -189,7 +189,7 @@ func runTier(cmd string, args []string) (err error) {
 		}
 		defer f.Close()
 
-		return pushJSON(ctx, f, func(f control.Feature, err error) {
+		err = pushJSON(ctx, f, func(f control.Feature, err error) {
 			link, uerr := url.JoinPath(dashURL[cc().Live()], "products", f.ProviderID)
 			if uerr != nil {
 				panic(uerr)
@@ -216,6 +216,11 @@ func runTier(cmd string, args []string) (err error) {
 				reason,
 			)
 		})
+		if errors.Is(err, control.ErrPlanExists) {
+			//lint:ignore ST1005 this error is not used like normal errors
+			return fmt.Errorf("tier: illegal attempt to push features to exiting plan(s); aborting.")
+		}
+		return err
 	case "pull":
 		data, err := tc().PullJSON(ctx)
 		if err != nil {


### PR DESCRIPTION
This change prevents features from being pushed to plans at specific
versions that have already been pushed.

Also remove old debug error prefix.

Fixes #120
