### PR TITLE
control: continue valid plans with bad plans

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -69,9 +69,6 @@ func isInvalidAccount(err error) bool {
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var err error
-	defer func() {
-		// h.logf("%s %s %s %s", r.RemoteAddr, r.Method, r.URL, err)
-	}()
 	bw := &byteCountResponseWriter{ResponseWriter: w}
 	err = h.serve(bw, r)
 	if isInvalidAccount(err) {


### PR DESCRIPTION
This commit relaxes the constraint on push that prevents valid plans from
being pushed with illegal attempts to push features into already pushed
plans.

A nice side effect of this is that Push is now faster because the
sentinel plans can be pushed concurrently.
