### PR TITLE
cmd/tier: display account specific URLs on push

### DIFF
--- a/cmd/tier/connect.go
+++ b/cmd/tier/connect.go
@@ -119,9 +119,9 @@ func getKey() (key, source string, err error) {
 		return "", "", err
 	}
 	if *flagLive {
-		return p.LiveAPIKey, profile.ConfigPath, nil
+		return p.LiveAPIKey, profile.ConfigPath(), nil
 	}
-	return p.TestAPIKey, profile.ConfigPath, nil
+	return p.TestAPIKey, profile.ConfigPath(), nil
 }
 
 //lint:ignore U1000 this type is used as a type parameter, but staticcheck seems to not be able to detect that yet. Remove this comment when staticcheck will stop complaining.

--- a/cmd/tier/report_test.go
+++ b/cmd/tier/report_test.go
@@ -33,7 +33,7 @@ func TestReport(t *testing.T) {
 	defer s.Close()
 
 	// test background process in foreground
-	tt := testtier(t)
+	tt := testtier(t, "")
 	tt.Unsetenv("DO_NOT_TRACK")
 	tt.Setenv("_TIER_BG_TASKS", "track")
 	tt.Setenv("_TIER_EVENTS", "{}")
@@ -46,7 +46,7 @@ func TestReport(t *testing.T) {
 	}
 
 	// test tier reports errors correctly
-	tt = testtier(t)
+	tt = testtier(t, "")
 	tt.Unsetenv("DO_NOT_TRACK")
 	tt.Setenv("TIER_TRACK_BASE_URL", s.URL)
 	tt.Setenv("STRIPE_API_KEY", "bad_key")

--- a/cmd/tier/update_test.go
+++ b/cmd/tier/update_test.go
@@ -31,7 +31,7 @@ func TestUpdate(t *testing.T) {
 		}
 	}
 
-	tt := testtier(t)
+	tt := testtier(t, "")
 	tt.Setenv("TIER_UPDATE_URL", c.URL+"?test=v100")
 	tt.Run("version")
 	tt.GrepStderrNot(`\bv100\b`, "unexpected mention of new version")

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -87,19 +87,19 @@ func Save(name string, p *Profile) error {
 	return e.Encode(c)
 }
 
-var ConfigPath string // set on init; treat as const
-
-func init() {
+// ConfigPath returns the path to the config file.
+func ConfigPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)
 	}
-	ConfigPath = filepath.Join(home, ".config", "tier", "config.json")
+	return filepath.Join(home, ".config", "tier", "config.json")
 }
 
 func open() (*os.File, error) {
-	if err := os.MkdirAll(filepath.Dir(ConfigPath), 0o700); err != nil {
+	path := ConfigPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return nil, err
 	}
-	return os.OpenFile(ConfigPath, os.O_CREATE|os.O_RDWR, 0o600)
+	return os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 }

--- a/stripe/client.go
+++ b/stripe/client.go
@@ -35,6 +35,21 @@ func MakeID(parts ...string) string {
 	return "tier__" + string(id)
 }
 
+// Link creates and returns a link to the Stripe dashboard for the provided
+// accountID followed by parts.
+//
+// If live is true, a link to the live dashboard is returned, otherwise a test
+// link is returned.
+func Link(live bool, accountID string, parts ...string) (string, error) {
+	var base string
+	if !live && accountID == "" {
+		base = "https://dashboard.stripe.com/test"
+	} else {
+		base = "https://dashboard.stripe.com"
+	}
+	return url.JoinPath(base, append([]string{accountID}, parts...)...)
+}
+
 type Error struct {
 	AccountID string
 	Type      string

--- a/stripe/client_test.go
+++ b/stripe/client_test.go
@@ -18,6 +18,29 @@ func newTestClient(t *testing.T, h func(w http.ResponseWriter, r *http.Request))
 	return c
 }
 
+func TestLink(t *testing.T) {
+	cases := []struct {
+		live      bool
+		accountID string
+		part      string
+		want      string
+	}{
+		{true, "acct_123", "foo", "https://dashboard.stripe.com/acct_123/foo"},
+		{true, "", "foo", "https://dashboard.stripe.com/foo"},
+		{false, "acct_123", "foo", "https://dashboard.stripe.com/acct_123/foo"},
+		{false, "", "foo", "https://dashboard.stripe.com/test/foo"},
+	}
+	for _, tc := range cases {
+		got, err := Link(tc.live, tc.accountID, tc.part)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.want {
+			t.Errorf("link(%v, %q, %q) = %q; want %q", tc.live, tc.accountID, tc.part, got, tc.want)
+		}
+	}
+}
+
 func TestFromEnv(t *testing.T) {
 	t.Setenv("STRIPE_API_KEY", "")
 	t.Setenv("STRIPE_BASE_API_URL", "")


### PR DESCRIPTION
This fixes a confusing bug that sent users to their default, logged-in
Stripe account even if they were using an isolated account with the
switch command.

The links displayed are now relative to the account the features were
pushed to.

This commit also reintroduces deep linking to prices pushed.

Fixes #166