### PR TITLE
cmd/tier: test cleanup

### DIFF
--- a/cmd/tier/tier.go
+++ b/cmd/tier/tier.go
@@ -68,7 +68,7 @@ func main() {
 	cmd := args[0]
 	if err := runTier(cmd, args[1:]); err != nil {
 		if isIsolationError(err) {
-			log.Fatalf("tier: Running in isloated mode without the API key that started it; See 'tier switch -h'.")
+			log.Fatalf("tier: Running in isolated mode without the API key that started it; See 'tier switch -h'.")
 		}
 		if errors.Is(err, errUsage) {
 			if err := help(stderr, cmd); err != nil {

--- a/cmd/tier/update_test.go
+++ b/cmd/tier/update_test.go
@@ -31,7 +31,7 @@ func TestUpdate(t *testing.T) {
 		}
 	}
 
-	tt := testtier(t, "acct_test")
+	tt := testtier(t, fatalHandler(t))
 	tt.Setenv("TIER_UPDATE_URL", c.URL+"?test=v100")
 	tt.Run("version")
 	tt.GrepStderrNot(`\bv100\b`, "unexpected mention of new version")

--- a/stripe/client.go
+++ b/stripe/client.go
@@ -195,7 +195,7 @@ func FromEnv() (*Client, error) {
 }
 
 func IsLiveKey(key string) bool {
-	return !strings.Contains(key, "_test_")
+	return strings.Contains(key, "_live_")
 }
 
 func (c *Client) Live() bool {


### PR DESCRIPTION
This commit changes test helpers to provide first-class support for
mocking out Stripe, making it easier for future tests to stay tight and
do the right thing.
