### PR TITLE
cmd/tier: make switch accept a url

### DIFF
--- a/cmd/tier/tier.go
+++ b/cmd/tier/tier.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"runtime"
 	"strconv"
@@ -403,7 +404,21 @@ the tier.state file.`)
 			if fs.NArg() < 1 {
 				return errUsage
 			}
-			a.ID = fs.Arg(0)
+			aid := fs.Arg(0)
+			u, _ := url.Parse(aid)
+			if u != nil {
+				parts := strings.Split(u.Path, "/")
+				for _, p := range parts {
+					if strings.HasPrefix(p, "acct_") {
+						aid = p
+						break
+					}
+				}
+			}
+			if !strings.HasPrefix(aid, "acct_") {
+				return fmt.Errorf("invalid account id or URL: %s", aid)
+			}
+			a.ID = aid
 		}
 		if err := saveState(a); err != nil {
 			return err

--- a/cmd/tier/tier_test.go
+++ b/cmd/tier/tier_test.go
@@ -137,7 +137,7 @@ func TestSwitchIsoloate(t *testing.T) {
 
 	tt.Run("switch", "-c")
 	tt.GrepStdout("Running in isolation mode.", "helpful message not printed")
-	tt.GrepStdout(`https://dashboard.stripe.com/acct_123/test`, "expected URL")
+	tt.GrepStdout(`\shttps://dashboard.stripe.com/acct_123/test`, "expected URL")
 
 	tt.RunFail("switch", "-c", "acct_123")
 	tt.GrepStderr("does not accept arguments", "expected error message")
@@ -155,7 +155,11 @@ func TestSwitchIsoloate(t *testing.T) {
 
 	tt.Run("switch", "acct_works")
 	tt.GrepStdout("Running in isolation mode.", "helpful message not printed")
-	tt.GrepStdout(`https://dashboard.stripe.com/acct_works/test`, "expected URL")
+	tt.GrepStdout(`\shttps://dashboard.stripe.com/acct_works/test`, "expected URL")
+
+	tt.Run("switch", "https://dashboard.stripe.com/acct_1M9f6lCYptJuIvl3/test/invoices/in_1M9fFICYptJuIvl3JQCXUdXj")
+	tt.GrepStdout("Running in isolation mode.", "helpful message not printed")
+	tt.GrepStdout(`\shttps://dashboard.stripe.com/acct_1M9f6lCYptJuIvl3/test$`, "expected URL")
 }
 
 func TestSwitchPreallocateTask(t *testing.T) {


### PR DESCRIPTION
This allows users to be lazy and paste a copied stripe dashboard URL,
and let the switch command extract the account ID from it, and switch to it.

Example:

  tier switch https://dashboard.stripe.com/acct_1M9f6lCYptJuIvl3/test/invoices/in_1M9fFICYptJuIvl3JQCXUdXj

Switch will ignore leading and trailing parts and look for the acct_ID
part for use.
