### PR TITLE
control: add hidden features

### DIFF
--- a/api/apitypes/model.go
+++ b/api/apitypes/model.go
@@ -49,6 +49,7 @@ func (t *Tier) UnmarshalJSON(data []byte) error {
 
 type Feature struct {
 	Title     string `json:"title,omitempty"`
+	Hidden    bool   `json:"hidden,omitempty"`
 	Base      int    `json:"base,omitempty"`
 	Mode      string `json:"mode,omitempty"`
 	Aggregate string `json:"aggregate,omitempty"`

--- a/api/materialize/views.go
+++ b/api/materialize/views.go
@@ -41,6 +41,7 @@ func FromPricingHuJSON(data []byte) (fs []control.Feature, err error) {
 			fn := feature.WithPlan(plan)
 			ff := control.Feature{
 				FeaturePlan: fn,
+				Hidden:      f.Hidden,
 
 				Currency: values.Coalesce(p.Currency, "usd"),
 				Interval: values.Coalesce(p.Interval, "@monthly"),
@@ -100,9 +101,10 @@ func ToPricingJSON(fs []control.Feature) ([]byte, error) {
 		}
 
 		p.Features[f.FeaturePlan.Name()] = apitypes.Feature{
-			Title: values.ZeroIf(f.Title, f.FeaturePlan.String()),
-			Base:  f.Base,
-			Tiers: tiers,
+			Title:  values.ZeroIf(f.Title, f.FeaturePlan.String()),
+			Hidden: f.Hidden,
+			Base:   f.Base,
+			Tiers:  tiers,
 		}
 		m.Plans[f.Plan()] = p
 	}

--- a/api/materialize/views_test.go
+++ b/api/materialize/views_test.go
@@ -16,6 +16,13 @@ import (
 func TestPricingHuJSON(t *testing.T) {
 	data := []byte(`{
 		"plans": {
+			"plan:hidden@1": {
+				"features": {
+					"feature:hidden": {
+						"hidden": true,
+					}
+				}
+			},
 			"plan:example@1": {
 				"title": "Just an example plan to show off features",
 				"features": {
@@ -73,6 +80,16 @@ func TestPricingHuJSON(t *testing.T) {
 				{Upto: tier.Inf, Price: 50, Base: 0},
 			},
 		},
+		{
+			PlanTitle:   "plan:hidden@1",
+			Title:       "feature:hidden@plan:hidden@1",
+			Hidden:      true,
+			FeaturePlan: refs.MustParseFeaturePlan("feature:hidden@plan:hidden@1"),
+			Currency:    "usd",
+			Interval:    "@monthly",
+			Mode:        "graduated",
+			Aggregate:   "sum",
+		},
 	}
 
 	diff.Test(t, t.Errorf, got, want)
@@ -103,6 +120,14 @@ func TestPricingHuJSON(t *testing.T) {
 						"base": 100,
 					}
 				}
+			},
+			"plan:hidden@1": {
+				"title": "plan:hidden@1",
+				"features": {
+					"feature:hidden": {
+						"hidden": true,
+					}
+				}
 			}
 		}
 	}`)
@@ -114,6 +139,7 @@ func diffJSON(t *testing.T, got, want []byte) {
 	t.Helper()
 
 	format := func(b []byte) string {
+		t.Helper()
 		b, err := hujson.Standardize(b)
 		if err != nil {
 			t.Fatal(err)

--- a/cmd/tier/tier.go
+++ b/cmd/tier/tier.go
@@ -235,16 +235,18 @@ func runTier(cmd string, args []string) (err error) {
 			"MODE",
 			"AGG",
 			"BASE",
+			"HIDDEN",
 		}, "\t"))
 
 		for plan, p := range m.Plans {
 			for feature, f := range p.Features {
-				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\n",
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%v\n",
 					plan,
 					feature,
 					f.Mode,
 					f.Aggregate,
 					f.Base,
+					f.Hidden,
 				)
 			}
 		}

--- a/control/client_test.go
+++ b/control/client_test.go
@@ -43,6 +43,13 @@ func TestRoundTrip(t *testing.T) {
 
 	want := []Feature{
 		{
+			FeaturePlan: refs.MustParseFeaturePlan("feature:test@plan:free@2"),
+			Interval:    "@daily",
+			Currency:    "usd",
+			Title:       "Test2",
+			Hidden:      true,
+		},
+		{
 			FeaturePlan: refs.MustParseFeaturePlan("feature:test@plan:free@3"),
 			Interval:    "@daily",
 			Currency:    "eur",

--- a/control/usage.go
+++ b/control/usage.go
@@ -63,6 +63,9 @@ func (c *Client) ReportUsage(ctx context.Context, org string, feature refs.Name,
 		default:
 		}
 		err := c.Stripe.Do(ctx, "POST", "/v1/subscription_items/"+itemID+"/usage_records", f, nil)
+		if stripe.IsInvalidRequest(err) {
+			return err
+		}
 		c.Logf("ReportUsage: %v", err)
 		bo.BackOff(ctx, err)
 		if err == nil {

--- a/refs/refs_test.go
+++ b/refs/refs_test.go
@@ -158,6 +158,36 @@ func TestRoundTrips(t *testing.T) {
 	testRoundTrip(t, ParsePlan, "plan:foo@0")
 }
 
+func TestFeaturePlanShort(t *testing.T) {
+	cases := []struct {
+		in  string
+		out string
+	}{
+		{in: "feature:foo@0", out: "foo@0"},
+		{in: "feature:foo@1", out: "foo@1"},
+		{in: "feature:foo@plan:free@0", out: "foo@free@0"},
+		{in: "feature:foo@plan:free@y", out: "foo@free@y"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.in, func(t *testing.T) {
+			fp, err := ParseFeaturePlan(tt.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := fp.Short(); got != tt.out {
+				t.Errorf("%q: Short() = %v, want %v", tt.in, got, tt.out)
+			}
+			rtfp, err := ParseFeaturePlanShort(fp.Short())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if fp != rtfp {
+				t.Errorf("roundtrip failed: %v != %v", fp, rtfp)
+			}
+		})
+	}
+}
+
 func testRoundTrip[T fmt.Stringer](t *testing.T, parse func(string) (T, error), s string) {
 	t.Helper()
 	n, err := parse(s)

--- a/stripe/errors.go
+++ b/stripe/errors.go
@@ -1,0 +1,15 @@
+package stripe
+
+func IsInvalidRequest(err error) bool {
+	return isErrorType(err, "invalid_request_error")
+}
+
+func isErrorType(err error, typ string) bool {
+	if err == nil {
+		return false
+	}
+	if se, ok := err.(*Error); ok {
+		return se.Type == typ
+	}
+	return false
+}


### PR DESCRIPTION
This allows pricing models to describe features that are "hidden,"; e.g.
they do not appear on invoices but act only as entitlements/limits.

A feature will be hidden and not made billable if the new feature field
is set like `hidden: true`.