### PR TITLE
api: support free trials

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -155,6 +155,7 @@ func (h *Handler) serveSubscribe(w http.ResponseWriter, r *http.Request) error {
 				return err
 			}
 			phases = append(phases, control.Phase{
+				Trial:     p.Trial,
 				Effective: p.Effective,
 				Features:  fs,
 			})

--- a/api/apitypes/apitypes.go
+++ b/api/apitypes/apitypes.go
@@ -19,6 +19,7 @@ func (e *Error) Error() string {
 }
 
 type Phase struct {
+	Trial     bool
 	Effective time.Time
 	Features  []string
 }

--- a/cmd/tier/help.go
+++ b/cmd/tier/help.go
@@ -124,15 +124,23 @@ The output is in the format:
 `,
 	"subscribe": `Usage:
 
-	tier [--live] subscribe [--email=<email>] <org> [plan|featurePlan]...
+	tier [--live] subscribe [flags] <org> [plan|featurePlan]...
 
 Tier subscribe creates or updates a subscription for the provided org, applying
 the features in the plan.
 
-If the --live flag is provided, your accounts live mode will be used.
+Flags:
 
-If the --email flag is provided, the org's email address will be set to the
-provided email address.
+	--email
+		set the org's email address
+	--trial days
+		set the org's trial period to the provided number of days. If
+		negative, the tial period will last indefinitely, and no other
+		phase will come after it.
+
+Global Flags:
+
+If the --live flag is provided, your accounts live mode will be used.
 `,
 	"limits": `Usage:
 

--- a/control/client.go
+++ b/control/client.go
@@ -321,7 +321,6 @@ type stripePrice struct {
 	stripe.ID
 	LookupKey string `json:"lookup_key"`
 	Metadata  struct {
-		Plan      string           `json:"tier.plan"`
 		PlanTitle string           `json:"tier.plan_title"`
 		Feature   refs.FeaturePlan `json:"tier.feature"`
 		Limit     string           `json:"tier.limit"`

--- a/control/schedule.go
+++ b/control/schedule.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kr/pretty"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"kr.dev/errorfmt"
@@ -19,7 +18,7 @@ import (
 // TODO(bmizerany): we don't support names in the MVP but the hook is
 // here as a reminder of the thought that has gone into it so far and
 // that we want to support it on subscribe.
-const scheduleNameTODO = "default"
+const subscriptionNameTODO = "default"
 
 // Errors
 var (
@@ -48,6 +47,8 @@ type Phase struct {
 	Features  []refs.FeaturePlan
 	Current   bool
 
+	Trial bool // Marks the phase as a trial phase. No fees will be incurred during a trial phase.
+
 	// Plans is the set of plans that are currently active for the phase. A
 	// plan is considered active in a phase if all of its features are
 	// listed in the phase. If any features from a plan is in the phase
@@ -69,11 +70,13 @@ func (p *Phase) Fragments() []refs.FeaturePlan {
 type subscription struct {
 	ID         string
 	ScheduleID string
+	Status     string
 	Name       string
 	Features   []Feature
 }
 
-func (c *Client) lookupSubscription(ctx context.Context, org, name string) (subscription, error) {
+func (c *Client) lookupSubscription(ctx context.Context, org, name string) (sub subscription, err error) {
+	defer errorfmt.Handlef("stripe: lookupSubscription: %s: %s: %w", org, name, &err)
 	cid, err := c.WhoIs(ctx, org)
 	if err != nil {
 		return subscription{}, err
@@ -85,17 +88,18 @@ func (c *Client) lookupSubscription(ctx context.Context, org, name string) (subs
 
 	type T struct {
 		stripe.ID
-		Items struct {
+		Status string
+		Items  struct {
 			Data []struct {
 				ID    string
 				Price stripePrice
 			}
 		}
+		Metadata struct {
+			Name string `json:"tier.subscription"`
+		}
 		Schedule struct {
-			ID       string
-			Metadata struct {
-				Name string `json:"tier.subscription"`
-			}
+			ID string
 		}
 	}
 
@@ -111,8 +115,11 @@ func (c *Client) lookupSubscription(ctx context.Context, org, name string) (subs
 	// over time.
 
 	v, err := stripe.List[T](ctx, c.Stripe, "GET", "/v1/subscriptions", f).Find(func(s T) bool {
-		return s.Schedule.Metadata.Name == name
+		return s.Metadata.Name == name
 	})
+	if err != nil {
+		return subscription{}, err
+	}
 
 	var fs []Feature
 	for _, v := range v.Items.Data {
@@ -121,13 +128,10 @@ func (c *Client) lookupSubscription(ctx context.Context, org, name string) (subs
 		fs = append(fs, f)
 	}
 
-	c.Logf("lookupSchedule: %+v", v)
-	if err != nil {
-		return subscription{}, err
-	}
 	s := subscription{
 		ID:         v.ProviderID(),
 		ScheduleID: v.Schedule.ID,
+		Status:     v.Status,
 		Features:   fs,
 	}
 	return s, nil
@@ -136,6 +140,8 @@ func (c *Client) lookupSubscription(ctx context.Context, org, name string) (subs
 func (c *Client) createSchedule(ctx context.Context, org, name string, fromSub string, info *OrgInfo, phases []Phase) (err error) {
 	defer errorfmt.Handlef("stripe: createSubscription: %q: %w", org, &err)
 
+	// Update customer regardless of whether we have phases to update or
+	// not.
 	cid, err := c.putCustomer(ctx, org, info)
 	if err != nil {
 		return err
@@ -144,8 +150,6 @@ func (c *Client) createSchedule(ctx context.Context, org, name string, fromSub s
 	if len(phases) == 0 {
 		return nil
 	}
-
-	c.Logf("keyprefix: %q", c.Stripe.KeyPrefix)
 
 	do := func(f stripe.Form) (string, error) {
 		var v struct {
@@ -158,6 +162,7 @@ func (c *Client) createSchedule(ctx context.Context, org, name string, fromSub s
 	}
 
 	if fromSub != "" {
+		defer errorfmt.Handlef("fromSub: %w", &err)
 		var f stripe.Form
 		f.Set("from_subscription", fromSub)
 		sid, err := do(f)
@@ -166,50 +171,30 @@ func (c *Client) createSchedule(ctx context.Context, org, name string, fromSub s
 		}
 		return c.updateSchedule(ctx, sid, name, phases)
 	} else {
+		defer errorfmt.Handlef("newSub: %w", &err)
 		var f stripe.Form
 		f.Set("customer", cid)
-		f.Set("metadata[tier.subscription]", name)
-		for i, p := range phases {
-			fs, err := c.lookupFeatures(ctx, p.Features)
-			if err != nil {
-				return err
-			}
-
-			if i == 0 {
-				f.Set("start_date", nowOrSpecific(p.Effective))
-			}
-
-			if i > 0 && i < len(phases)-1 {
-				f.Set("phases", i-1, "end_date", nowOrSpecific(p.Effective))
-			}
-
-			for j, fe := range fs {
-				c.Logf("phase %d, item %d: %v", i, j, fe)
-				f.Set("phases", i, "items", j, "price", fe.ProviderID)
-			}
+		if err := addPhases(ctx, c, &f, false, name, phases); err != nil {
+			return err
 		}
 		_, err := do(f)
 		return err
 	}
 }
 
-func (c *Client) updateSchedule(ctx context.Context, id, name string, phases []Phase) (err error) {
-	defer errorfmt.Handlef("stripe: updateSchedule: %q: %w", id, &err)
-
-	if id == "" {
+func (c *Client) updateSchedule(ctx context.Context, schedID, name string, phases []Phase) (err error) {
+	defer errorfmt.Handlef("stripe: updateSchedule: %q: %w", schedID, &err)
+	if schedID == "" {
 		return errors.New("subscription id required")
 	}
-
 	var f stripe.Form
-	if name != "" {
-		// When creating a schedule using from_schedule we cannot set
-		// metadata, so we must wait until the update that immediately
-		// follows to do so. This is why updating the name is allowed
-		// if necessary.
-		//
-		// Error from stripe: "You cannot set `metadata` if `from_subscription` is set."
-		f.Set("metadata[tier.subscription]", name)
+	if err := addPhases(ctx, c, &f, true, name, phases); err != nil {
+		return err
 	}
+	return c.Stripe.Do(ctx, "POST", "/v1/subscription_schedules/"+schedID, f, nil)
+}
+
+func addPhases(ctx context.Context, c *Client, f *stripe.Form, update bool, name string, phases []Phase) error {
 	for i, p := range phases {
 		if len(p.Features) == 0 {
 			return fmt.Errorf("phase %d must contain at least one feature", i)
@@ -223,17 +208,26 @@ func (c *Client) updateSchedule(ctx context.Context, id, name string, phases []P
 			return ErrFeatureNotFound
 		}
 
+		f.Set("phases", i, "metadata[tier.subscription]", name)
+		f.Set("phases", i, "trial", p.Trial)
+
 		if i == 0 {
-			f.Set("phases", 0, "start_date", nowOrSpecific(p.Effective))
+			if update {
+				f.Set("phases", 0, "start_date", nowOrSpecific(p.Effective))
+			} else {
+				f.Set("start_date", nowOrSpecific(p.Effective))
+			}
 		} else {
 			f.Set("phases", i-1, "end_date", nowOrSpecific(p.Effective))
-			f.Set("phases", i, "start_date", nowOrSpecific(p.Effective))
+			if update {
+				f.Set("phases", i, "start_date", nowOrSpecific(p.Effective))
+			}
 		}
 		for j, fe := range fs {
 			f.Set("phases", i, "items", j, "price", fe.ProviderID)
 		}
 	}
-	return c.Stripe.Do(ctx, "POST", "/v1/subscription_schedules/"+id, f, nil)
+	return nil
 }
 
 func (c *Client) Schedule(ctx context.Context, org string, info *OrgInfo, phases []Phase) (err error) {
@@ -247,8 +241,6 @@ func (c *Client) Schedule(ctx context.Context, org string, info *OrgInfo, phases
 
 func (c *Client) schedule(ctx context.Context, org string, info *OrgInfo, phases []Phase) (err error) {
 	defer errorfmt.Handlef("tier: schedule: %q: %w", org, &err)
-
-	c.Logf("Subscribe phases: %# v", pretty.Formatter(phases))
 
 	for i, p := range phases {
 		if len(p.Features) > 20 {
@@ -265,24 +257,28 @@ func (c *Client) schedule(ctx context.Context, org string, info *OrgInfo, phases
 		}
 	}
 
-	s, err := c.lookupSubscription(ctx, org, scheduleNameTODO)
+	s, err := c.lookupSubscription(ctx, org, subscriptionNameTODO)
 	if errors.Is(err, ErrOrgNotFound) {
 		// We only need to pay the API penalty of creating a customer
 		// if we know in fact it does not exist.
 		if _, err := c.putCustomer(ctx, org, info); err != nil {
 			return err
 		}
-		return c.createSchedule(ctx, org, scheduleNameTODO, "", info, phases)
+		return c.createSchedule(ctx, org, subscriptionNameTODO, "", info, phases)
 	}
 	if errors.Is(err, stripe.ErrNotFound) {
-		return c.createSchedule(ctx, org, scheduleNameTODO, "", info, phases)
+		return c.createSchedule(ctx, org, subscriptionNameTODO, "", info, phases)
 	}
 	if err != nil {
 		return err
 	}
-	err = c.updateSchedule(ctx, s.ScheduleID, scheduleNameTODO, phases)
-	if isReleased(err) {
-		return c.createSchedule(ctx, org, scheduleNameTODO, s.ScheduleID, info, phases)
+	if s.ScheduleID != "" {
+		err = c.updateSchedule(ctx, s.ScheduleID, subscriptionNameTODO, phases)
+		if isReleased(err) {
+			return c.createSchedule(ctx, org, subscriptionNameTODO, s.ID, info, phases)
+		}
+	} else {
+		return c.createSchedule(ctx, org, subscriptionNameTODO, s.ID, info, phases)
 	}
 	return err
 }
@@ -318,6 +314,7 @@ func (c *Client) ScheduleNow(ctx context.Context, org string, info *OrgInfo, pha
 			if p.Current {
 				p0 := phases[0]
 				p.Features = p0.Features
+				p.Trial = p0.Trial
 				phases[0] = p
 				break
 			}
@@ -354,7 +351,7 @@ func (c *Client) lookupFeatures(ctx context.Context, keys []refs.FeaturePlan) ([
 		}
 
 		if len(pp) != len(keys) {
-			// TODO(bmizerany): return a more specific error with omitted features
+			// TODO(bmizerany): report which feature(s) was/are not found
 			return nil, ErrFeatureNotFound
 		}
 
@@ -390,6 +387,14 @@ func notFoundAsNil(err error) error {
 	return err
 }
 
+func (c *Client) LookupStatus(ctx context.Context, org string) (string, error) {
+	s, err := c.lookupSubscription(ctx, org, subscriptionNameTODO)
+	if err != nil {
+		return "", err
+	}
+	return s.Status, nil
+}
+
 func (c *Client) LookupPhases(ctx context.Context, org string) (ps []Phase, err error) {
 	defer errorfmt.Handlef("LookupPhase: %w", &err)
 
@@ -400,14 +405,14 @@ func (c *Client) LookupPhases(ctx context.Context, org string) (ps []Phase, err 
 
 	type T struct {
 		stripe.ID
-		Metadata struct {
-			Name string `json:"tier.subscription"`
-		}
 		Current struct {
 			Start int64 `json:"start_date"`
 			End   int64 `json:"end_date"`
 		} `json:"current_phase"`
 		Phases []struct {
+			Metadata struct {
+				Name string `json:"tier.subscription"`
+			}
 			Start int64 `json:"start_date"`
 			Items []struct {
 				Price stripePrice
@@ -449,8 +454,14 @@ func (c *Client) LookupPhases(ctx context.Context, org string) (ps []Phase, err 
 
 	for _, s := range ss {
 		const name = "default" // TODO(bmizerany): support multiple subscriptions by name
-		c.Logf("subscription schedule: %# v", pretty.Formatter(s))
-		if s.Metadata.Name != name {
+		var skip bool
+		for _, p := range s.Phases {
+			if p.Metadata.Name != name {
+				skip = true
+				break
+			}
+		}
+		if skip {
 			continue
 		}
 		for _, p := range s.Phases {
@@ -488,6 +499,111 @@ func (c *Client) LookupPhases(ctx context.Context, org string) (ps []Phase, err 
 	})
 
 	return ps, nil
+}
+
+type Period struct {
+	Effective time.Time
+	End       time.Time
+}
+
+type Invoice struct {
+	Amount float64
+	Period Period
+	Lines  []InvoiceLineItem
+
+	SubtotalPreTax int
+	Subtotal       int
+	TotalPreTax    int
+	Total          int
+}
+
+type InvoiceLineItem struct {
+	Period    Period
+	Feature   refs.FeaturePlan
+	Quantity  int
+	Amount    float64
+	Proration bool
+
+	// TODO(bmizerany): add more fields
+}
+
+type stripeInvoiceLineItem struct {
+	Period struct {
+		Start int64 `json:"start"`
+		End   int64 `json:"end"`
+	}
+
+	// Price is unable to collect Tiers because the
+	// price object itself is not expandable
+	// because it is the 4th level of nesting, and
+	// the maximum level of nesting is 4.
+	Price        stripePrice
+	Amount       float64
+	Quantity     int
+	AmountPreTax int `json:"amount_excluding_tax"`
+	Currency     string
+	Proration    bool
+}
+
+func (c *Client) LookupInvoices(ctx context.Context, org string) ([]Invoice, error) {
+	// /v1/invoices
+
+	// slurp all invoices for org using the code already in this file
+	cid, err := c.WhoIs(ctx, org)
+	if err != nil {
+		return nil, notFoundAsNil(err)
+	}
+
+	var f stripe.Form
+	f.Set("customer", cid)
+
+	type T struct {
+		// https://stripe.com/docs/api/invoices/object
+		stripe.ID
+		PeriodStart          int64 `json:"period_start"`
+		PeriodEnd            int64 `json:"period_end"`
+		SubtotalExcludingTax int   `json:"subtotal_excluding_tax"`
+		Subtotal             int   `json:"subtotal"`
+		TotalExcludingTax    int   `json:"total_excluding_tax"`
+		Total                int   `json:"total"`
+		Lines                struct {
+			Data []stripeInvoiceLineItem
+		}
+	}
+
+	sins, err := stripe.Slurp[T](ctx, c.Stripe, "GET", "/v1/invoices", f)
+	if err != nil {
+		return nil, err
+	}
+
+	var ins []Invoice
+	for _, in := range sins {
+		var lines []InvoiceLineItem
+		for _, line := range in.Lines.Data {
+			lines = append(lines, InvoiceLineItem{
+				Period: Period{
+					Effective: time.Unix(line.Period.Start, 0),
+					End:       time.Unix(line.Period.End, 0),
+				},
+				Feature:   line.Price.Metadata.Feature,
+				Quantity:  line.Quantity,
+				Amount:    line.Amount,
+				Proration: line.Proration,
+			})
+		}
+		ins = append(ins, Invoice{
+			Period: Period{
+				Effective: time.Unix(in.PeriodStart, 0),
+				End:       time.Unix(in.PeriodEnd, 0),
+			},
+			Lines:          lines,
+			SubtotalPreTax: in.SubtotalExcludingTax,
+			Subtotal:       in.Subtotal,
+			TotalPreTax:    in.TotalExcludingTax,
+			Total:          in.Total,
+		})
+	}
+	return ins, nil
 }
 
 // PutCustomer safely creates or updates a customer in Stripe. It does this
@@ -563,12 +679,12 @@ func (c *Client) Isolated() bool {
 }
 
 func (c *Client) WhoIs(ctx context.Context, org string) (id string, err error) {
+	defer errorfmt.Handlef("whois: %q: %w", org, &err)
 	if !strings.HasPrefix(org, "org:") {
 		return "", &ValidationError{Message: "org must be prefixed with \"org:\""}
 	}
 
 	cid, err := c.cache.load(org, func() (string, error) {
-		c.Logf("WhoIs: cache miss: looking up customer for %q", org)
 		type T struct {
 			stripe.ID
 			Email    string

--- a/control/usage.go
+++ b/control/usage.go
@@ -29,7 +29,7 @@ type Usage struct {
 }
 
 func (c *Client) ReportUsage(ctx context.Context, org string, feature refs.Name, use Report) error {
-	itemID, isMetered, err := c.lookupSubscriptionItemID(ctx, org, scheduleNameTODO, feature)
+	itemID, isMetered, err := c.lookupSubscriptionItemID(ctx, org, subscriptionNameTODO, feature)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func (c *Client) LookupLimits(ctx context.Context, org string) ([]Usage, error) 
 }
 
 func (c *Client) lookupSubscriptionItemID(ctx context.Context, org, name string, feature refs.Name) (id string, isMetered bool, err error) {
-	defer errorfmt.Handlef("lookupSubscriptionItemID: %w", &err)
+	defer errorfmt.Handlef("lookupSubscriptionItemID: %s: %s: %s: %w", org, name, feature, &err)
 	s, err := c.lookupSubscription(ctx, org, name)
 	if err != nil {
 		return "", false, err

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
+	github.com/google/go-cmp v0.5.8
 	github.com/kr/pretty v0.3.0
 	github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
@@ -11,13 +12,14 @@ require (
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/tools v0.1.12
 	honnef.co/go/tools v0.3.3
-	kr.dev/diff v0.3.1-0.20221025214654-4c9427f2d4d4
+	kr.dev/diff v0.3.1-0.20221219052439-de28753499d5
 	kr.dev/errorfmt v0.1.1
 	tailscale.com v1.22.2
 )
 
 require (
 	github.com/BurntSushi/toml v0.4.1 // indirect
+	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -61,6 +62,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -252,8 +255,12 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.3.3 h1:oDx7VAwstgpYpb3wv0oxiZlxY+foCpRAwY7Vk6XpAgA=
 honnef.co/go/tools v0.3.3/go.mod h1:jzwdWgg7Jdq75wlfblQxO4neNaFFSvgc1tD5Wv8U0Yw=
 inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6 h1:acCzuUSQ79tGsM/O50VRFySfMm19IoMKL+sZztZkCxw=
+kr.dev/diff v0.3.0 h1:o/T8/tkAq9IuRIuFqCupyKPC5iSY3WXpVZ2p6ZK3Emw=
+kr.dev/diff v0.3.0/go.mod h1:XiTaLOg2/PD0cmXY7WQXUR8RAF3RwWpqIQEj910J2NY=
 kr.dev/diff v0.3.1-0.20221025214654-4c9427f2d4d4 h1:ZcjL0VwOD/389Sv4o958rLIRnni/VsEp8BZ5B0KcjCA=
 kr.dev/diff v0.3.1-0.20221025214654-4c9427f2d4d4/go.mod h1:XiTaLOg2/PD0cmXY7WQXUR8RAF3RwWpqIQEj910J2NY=
+kr.dev/diff v0.3.1-0.20221219052439-de28753499d5 h1:4xJQfUADAsPnD/obgH0ZOSj+8gQ5EAgxLhGx6FmHinI=
+kr.dev/diff v0.3.1-0.20221219052439-de28753499d5/go.mod h1:XiTaLOg2/PD0cmXY7WQXUR8RAF3RwWpqIQEj910J2NY=
 kr.dev/errorfmt v0.1.1 h1:0YA5N2yV0xKxJ4eD5cX2S9wEnJHDHOZzerKbrZqtRrQ=
 kr.dev/errorfmt v0.1.1/go.mod h1:X5EQZa3qf6c/l1DMjhflAbKGAGvlP6/ByWnaOpfbJME=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/stripe/stroke/stroke.go
+++ b/stripe/stroke/stroke.go
@@ -75,6 +75,7 @@ func createAccount(c *stripe.Client, logf func(string, ...any)) (string, error) 
 
 type Clock struct {
 	id      string
+	helper  func()
 	advance func(time.Time)
 
 	sync   func()
@@ -121,7 +122,8 @@ func NewClock(t *testing.T, c *stripe.Client, name string, start time.Time) *Clo
 
 	var cl *Clock
 	cl = &Clock{
-		id: v.ID,
+		id:     v.ID,
+		helper: t.Helper,
 		advance: func(now time.Time) {
 			var f stripe.Form
 			f.Set("frozen_time", now)
@@ -148,6 +150,7 @@ func (c *Clock) ID() string           { return c.id }
 func (c *Clock) DashboardURL() string { return c.dashURL }
 
 func (c *Clock) Advance(t time.Time) {
+	c.helper()
 	c.advance(t)
 	bo := backoff.NewBackoff("stroke: clock: advance backoff", c.logf, 5*time.Second)
 	for {


### PR DESCRIPTION
This changes the API to accept a Trial field for a Phase making it trial
phase in Stripe, avoid any incurring of fees until the end of the trial.

This also adds the --trial=<days> flag to the CLI subscribe subcommand
for specifying that the features listed will be available in two phases,
the first is the trial phase that lasts the number of days specified,
and the next is the paid phase that lasts indefinitely.
