### PR TITLE
api: detect and report lingering idempotency keys

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -29,6 +29,11 @@ var errorLookup = map[error]error{
 		Code:    "feature_not_found",
 		Message: "feature not found",
 	},
+	control.ErrUnexpectedMissingOrg: &trweb.HTTPError{
+		Status:  500,
+		Code:    "TERR1050",
+		Message: "Stripe reported a customer was created and then reported it did not exist. This might mean you purged your Test Mode and need to reset TIER_PREFIX_KEY=<randomString>.",
+	},
 	control.ErrFeatureNotMetered: &trweb.HTTPError{ // TODO(bmizerany): this may be relaxed if we decide to log and accept
 		Status:  400,
 		Code:    "invalid_request",


### PR DESCRIPTION
Stripe Idemptency Keys linger after a Test Mode data purge, causing
false positive responses from Stripe. One such scenario is creating a
customer using a deterministic Idempotency Key with a Tier orgID (e.g.
"create:customer:org:example") to suppress a duplicate request from a
dueling client. If after that key is created, and our Test Mode is
purged, we'll get a cached response back from Stripe telling us the
customer was created and give us the old response without actually
creating the customer in the now clean Test Mode. Using that customer ID
to create a subscription resulted in a "resource_not_found" error from
Stripe because the customer did not exist.

Tier now detects an error resulting from a lingering idempotency key
when creating a schedule for a customer that was thought to be created
just before attempting to create the schedule. The output should now be
more helpful.

This commit also introduces the new error code scheme with an error code
prefixed with ("TERR"). It is pronounced, "terror". Moving forward, all
new errors will have a TERR-code. This makes specific errors easier to
report and search for.