### PR TITLE
api: add subscription cancelation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -146,7 +146,6 @@ func (h *Handler) serveSubscribe(w http.ResponseWriter, r *http.Request) error {
 	if err := trweb.DecodeStrict(r, &sr); err != nil {
 		return err
 	}
-
 	var phases []control.Phase
 	if len(sr.Phases) > 0 {
 		m, err := h.c.Pull(r.Context(), 0)
@@ -166,9 +165,13 @@ func (h *Handler) serveSubscribe(w http.ResponseWriter, r *http.Request) error {
 			})
 		}
 	}
-
-	info := (*control.OrgInfo)(sr.Info)
-	return h.c.ScheduleNow(r.Context(), sr.Org, info, phases)
+	if sr.Info != nil {
+		info := (*control.OrgInfo)(sr.Info)
+		if err := h.c.PutCustomer(r.Context(), sr.Org, info); err != nil {
+			return err
+		}
+	}
+	return h.c.ScheduleNow(r.Context(), sr.Org, phases)
 }
 
 func (h *Handler) serveReport(w http.ResponseWriter, r *http.Request) error {

--- a/cmd/tier/tier_test.go
+++ b/cmd/tier/tier_test.go
@@ -532,7 +532,8 @@ const responsePricesValidPlan = `
 
 func TestSubscribeUnexpectedMissingCustomer(t *testing.T) {
 	tt := testtier(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v1/subscription_schedules" {
+		t.Logf("request: %s %s", r.Method, r.URL.Path)
+		if wants(r, "POST", "/v1/subscription_schedules") {
 			w.WriteHeader(400)
 			io.WriteString(w, `{
 				"error": {
@@ -563,4 +564,8 @@ func chdir(t *testing.T, dir string) {
 			panic(err)
 		}
 	})
+}
+
+func wants(r *http.Request, method, path string) bool {
+	return r.Method == method && r.URL.Path == path
 }

--- a/control/usage.go
+++ b/control/usage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
@@ -88,6 +89,12 @@ func (c *Client) LookupLimits(ctx context.Context, org string) ([]Usage, error) 
 	}
 
 	lines, err := stripe.Slurp[T](ctx, c.Stripe, "GET", "/v1/invoices/upcoming/lines", f)
+	var se *stripe.Error
+	if errors.As(err, &se) {
+		if se.Code == "invoice_upcoming_none" {
+			return nil, nil
+		}
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit changes /v1/subscribe to accept an update consisting solely
of one zero-value phase. Such an update represents the desire to cancel
the org schedule effective immediately.