### PR TITLE
cmd/tier: add -cancel flag to subscribe command

### DIFF
--- a/cmd/tier/cline/cline.go
+++ b/cmd/tier/cline/cline.go
@@ -116,7 +116,7 @@ func (d *Data) RunFail(args ...string) {
 func (d *Data) Run(args ...string) {
 	d.t.Helper()
 	if err := d.doRun(args...); err != nil {
-		d.t.Fatal(err)
+		d.t.Fatalf("unexpected failure: %v", err)
 	}
 }
 

--- a/cmd/tier/help.go
+++ b/cmd/tier/help.go
@@ -137,6 +137,9 @@ Flags:
 		set the org's trial period to the provided number of days. If
 		negative, the tial period will last indefinitely, and no other
 		phase will come after it.
+	--cancel
+		cancel the org's subscription. It is an error to provide a plan
+		or featurePlan with this flag.
 
 Global Flags:
 

--- a/cmd/tier/tier.go
+++ b/cmd/tier/tier.go
@@ -256,6 +256,7 @@ func runTier(cmd string, args []string) (err error) {
 		fs := flag.NewFlagSet(cmd, flag.ExitOnError)
 		email := fs.String("email", "", "sets the customer email address")
 		trial := fs.Int("trial", 0, "sets the trial period in days")
+		cancel := fs.Bool("cancel", false, "cancels the subscription")
 		if err := fs.Parse(args); err != nil {
 			return err
 		}
@@ -268,6 +269,17 @@ func runTier(cmd string, args []string) (err error) {
 				Email: *email,
 			},
 		}
+
+		// the cancel must be used without arguments
+		if *cancel && fs.NArg() > 1 {
+			fmt.Fprintln(stderr, "tier: the -cancel flag must be used without arguments")
+			return errUsage
+		}
+
+		if *cancel {
+			p.Phases = []tier.Phase{{}}
+		}
+
 		var refs []string
 		if fs.NArg() > 1 {
 			refs = fs.Args()[1:]
@@ -290,6 +302,7 @@ func runTier(cmd string, args []string) (err error) {
 				p.Phases = []tier.Phase{{Features: refs}}
 			}
 		}
+
 		vlogf("subscribing %s to %v", org, refs)
 		return tc().Schedule(ctx, org, p)
 	case "phases":

--- a/control/schedule.go
+++ b/control/schedule.go
@@ -301,7 +301,7 @@ func isReleased(err error) bool {
 }
 
 func (c *Client) scheduleCancel(ctx context.Context, org string) (err error) {
-	defer errorfmt.Handlef("tier: ScheduleCancel: %q: %w", org, &err)
+	defer errorfmt.Handlef("tier: scheduleCancel: %q: %w", org, &err)
 	s, err := c.lookupSubscription(ctx, org, subscriptionNameTODO)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds support for canceling a subscription for an org via the
subscribe sub-command.