### PR TITLE
api: report 400 if plan or feature not found

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -191,6 +191,12 @@ func TestAPISubscribe(t *testing.T) {
 		Code:    "feature_not_found",
 		Message: "feature not found",
 	})
+
+	sub("org:test", []string{"plan:nope@0"}, &apitypes.Error{
+		Status:  400,
+		Code:    "TERR1020",
+		Message: "feature or plan not found",
+	})
 }
 
 func TestPhaseBadOrg(t *testing.T) {

--- a/control/client.go
+++ b/control/client.go
@@ -19,6 +19,7 @@ import (
 var (
 	ErrFeatureExists     = errors.New("feature already exists")
 	ErrFeatureNotFound   = errors.New("feature not found")
+	ErrNoFeatures        = errors.New("no features")
 	ErrFeatureNotMetered = errors.New("feature is not metered")
 	ErrPlanExists        = errors.New("plan already exists")
 	ErrInvalidEmail      = errors.New("invalid email")
@@ -413,7 +414,7 @@ func Expand(fs []Feature, names ...string) ([]refs.FeaturePlan, error) {
 				}
 			}
 			if len(out) == n {
-				return nil, fmt.Errorf("no features found for plan %q", p)
+				return nil, fmt.Errorf("%w found for plan %q", ErrNoFeatures, p)
 			}
 		} else {
 			out = append(out, fp)


### PR DESCRIPTION
Previously, the API would return a 500 if the user supplied a non-existent feature or plan.

There is more work to do on error reporting, but this commit provides clarity to the user with a clear error message.

Fixes #211