### PR TITLE
cmd/tier: accept -checkout on subscribe

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -13,6 +13,7 @@ import (
 	"tier.run/api/apitypes"
 	"tier.run/api/materialize"
 	"tier.run/control"
+	"tier.run/refs"
 	"tier.run/stripe"
 	"tier.run/trweb"
 	"tier.run/values"
@@ -124,12 +125,21 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if trweb.WriteError(w, lookupErr(err)) || trweb.WriteError(w, err) {
 		return
 	}
-	var e *control.ValidationError
-	if errors.As(err, &e) {
+	var ve *control.ValidationError
+	if errors.As(err, &ve) {
 		trweb.WriteError(w, &trweb.HTTPError{
 			Status:  400,
 			Code:    "invalid_request",
-			Message: e.Message,
+			Message: ve.Message,
+		})
+		return
+	}
+	var pe *refs.ParseError
+	if errors.As(err, &pe) {
+		trweb.WriteError(w, &trweb.HTTPError{
+			Status:  400,
+			Code:    "invalid_request",
+			Message: pe.Message,
 		})
 		return
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -196,6 +196,17 @@ func (h *Handler) serveSubscribe(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
+	if sr.Checkout != nil {
+		cp := (*control.CheckoutParams)(sr.Checkout)
+		link, err := h.c.Checkout(r.Context(), sr.Org, phases, cp)
+		if err != nil {
+			return err
+		}
+		return httpJSON(w, &apitypes.ScheduleResponse{
+			CheckoutURL: link,
+		})
+	}
+
 	if len(phases) == 0 {
 		return nil
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -220,8 +220,8 @@ func TestAPISubscribe(t *testing.T) {
 
 	sub("org:test", []string{"plan:test@0", "feature:nope@0"}, &apitypes.Error{
 		Status:  400,
-		Code:    "feature_not_found",
-		Message: "feature not found",
+		Code:    "TERR1020",
+		Message: "feature or plan not found",
 	})
 
 	sub("org:test", []string{"plan:nope@0"}, &apitypes.Error{

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -52,33 +52,25 @@ func TestAPICheckout(t *testing.T) {
 	}}
 	cc.Push(ctx, m, pushLogger(t))
 
-	cp := &apitypes.CheckoutParams{SuccessURL: "https://example.com/success"}
-
 	t.Run("card setup", func(t *testing.T) {
-		r, err := tc.Schedule(ctx, "org:test", &tier.ScheduleParams{
-			Checkout: cp,
-			// No phases == card setup.
-		})
+		r, err := tc.Checkout(ctx, "org:test", "https://example.com/success", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("checkout: %s", r.CheckoutURL)
-		if r.CheckoutURL == "" {
+		t.Logf("checkout: %s", r.URL)
+		if r.URL == "" {
 			t.Error("unexpected empty checkout url")
 		}
 	})
 	t.Run("subscription", func(t *testing.T) {
-		r, err := tc.Schedule(ctx, "org:test", &tier.ScheduleParams{
-			Checkout: cp,
-			Phases: []tier.Phase{{
-				Features: []string{"feature:x@plan:test@0"},
-			}},
+		r, err := tc.Checkout(ctx, "org:test", "https://example.com/success", &tier.CheckoutParams{
+			Features: []string{"feature:x@plan:test@0"},
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("checkout: %s", r.CheckoutURL)
-		if r.CheckoutURL == "" {
+		t.Logf("checkout: %s", r.URL)
+		if r.URL == "" {
 			t.Error("unexpected empty checkout url")
 		}
 	})

--- a/api/apitypes/apitypes.go
+++ b/api/apitypes/apitypes.go
@@ -32,7 +32,7 @@ type PhaseResponse struct {
 }
 
 type InvoiceSettings struct {
-	DefaultPaymentMethod string
+	DefaultPaymentMethod string `json:"default_payment_method"`
 }
 
 type OrgInfo struct {
@@ -42,14 +42,25 @@ type OrgInfo struct {
 	Phone       string            `json:"phone"`
 	Metadata    map[string]string `json:"metadata"`
 
-	PaymentMethod   string
-	InvoiceSettings InvoiceSettings
+	PaymentMethod   string          `json:"payment_method"`
+	InvoiceSettings InvoiceSettings `json:"invoice_settings"`
+}
+
+type CheckoutParams struct {
+	SuccessURL string `json:"success_url"`
+	CancelURL  string `json:"cancel_url"`
 }
 
 type ScheduleRequest struct {
 	Org    string
 	Info   *OrgInfo
 	Phases []Phase
+
+	Checkout *CheckoutParams
+}
+
+type ScheduleResponse struct {
+	CheckoutURL string `json:"checkout_url,omitempty"`
 }
 
 type ReportRequest struct {

--- a/api/apitypes/apitypes.go
+++ b/api/apitypes/apitypes.go
@@ -19,9 +19,9 @@ func (e *Error) Error() string {
 }
 
 type Phase struct {
-	Trial     bool
-	Effective time.Time
-	Features  []string
+	Trial     bool      `json:"trial,omitempty"`
+	Effective time.Time `json:"effective,omitempty"`
+	Features  []string  `json:"features,omitempty"`
 }
 
 type PhaseResponse struct {
@@ -47,17 +47,17 @@ type OrgInfo struct {
 }
 
 type CheckoutRequest struct {
-	Org        string
-	TrialDays  int
-	Features   []string
-	SuccessURL string
-	CancelURL  string
+	Org        string   `json:"org"`
+	TrialDays  int      `json:"trial_days"`
+	Features   []string `json:"features"`
+	SuccessURL string   `json:"success_url"`
+	CancelURL  string   `json:"cancel_url"`
 }
 
 type ScheduleRequest struct {
-	Org    string
-	Info   *OrgInfo
-	Phases []Phase
+	Org    string   `json:"org"`
+	Info   *OrgInfo `json:"info"`
+	Phases []Phase  `json:"phases"`
 }
 
 // ScheduleResponse is the expected response from a schedule request. It is
@@ -65,15 +65,15 @@ type ScheduleRequest struct {
 type ScheduleResponse struct{}
 
 type CheckoutResponse struct {
-	URL string
+	URL string `json:"url"`
 }
 
 type ReportRequest struct {
-	Org     string
-	Feature refs.Name
-	N       int
-	At      time.Time // default is time.Now()
-	Clobber bool
+	Org     string    `json:"org"`
+	Feature refs.Name `json:"feature"`
+	N       int       `json:"n"`
+	At      time.Time `json:"at"`
+	Clobber bool      `json:"clobber"`
 }
 
 type WhoIsResponse struct {

--- a/api/apitypes/apitypes.go
+++ b/api/apitypes/apitypes.go
@@ -46,21 +46,26 @@ type OrgInfo struct {
 	InvoiceSettings InvoiceSettings `json:"invoice_settings"`
 }
 
-type CheckoutParams struct {
-	SuccessURL string `json:"success_url"`
-	CancelURL  string `json:"cancel_url"`
+type CheckoutRequest struct {
+	Org        string
+	TrialDays  int
+	Features   []string
+	SuccessURL string
+	CancelURL  string
 }
 
 type ScheduleRequest struct {
 	Org    string
 	Info   *OrgInfo
 	Phases []Phase
-
-	Checkout *CheckoutParams
 }
 
-type ScheduleResponse struct {
-	CheckoutURL string `json:"checkout_url,omitempty"`
+// ScheduleResponse is the expected response from a schedule request. It is
+// currently empty, reserved for furture use.
+type ScheduleResponse struct{}
+
+type CheckoutResponse struct {
+	URL string
 }
 
 type ReportRequest struct {

--- a/client/tier/client.go
+++ b/client/tier/client.go
@@ -240,20 +240,21 @@ func (c *Client) Subscribe(ctx context.Context, org string, featuresAndPlans ...
 
 type Phase = apitypes.Phase
 type OrgInfo = apitypes.OrgInfo
+type CheckoutParams = apitypes.CheckoutParams
 
 type ScheduleParams struct {
-	Info   *OrgInfo
-	Phases []Phase
+	Info     *OrgInfo
+	Phases   []Phase
+	Checkout *CheckoutParams
 }
 
-func (c *Client) Schedule(ctx context.Context, org string, p *ScheduleParams) error {
-	_, err := fetch.OK[struct{}, *apitypes.Error](ctx, c.client(), "POST", c.baseURL("/v1/subscribe"), &apitypes.ScheduleRequest{
-		Org:    org,
-		Info:   (*apitypes.OrgInfo)(p.Info),
-		Phases: copyPhases(p.Phases),
+func (c *Client) Schedule(ctx context.Context, org string, p *ScheduleParams) (*apitypes.ScheduleResponse, error) {
+	return fetch.OK[*apitypes.ScheduleResponse, *apitypes.Error](ctx, c.client(), "POST", c.baseURL("/v1/subscribe"), &apitypes.ScheduleRequest{
+		Org:      org,
+		Info:     (*apitypes.OrgInfo)(p.Info),
+		Phases:   copyPhases(p.Phases),
+		Checkout: p.Checkout,
 	})
-
-	return err
 }
 
 func copyPhases(phases []Phase) []apitypes.Phase {

--- a/client/tier/client.go
+++ b/client/tier/client.go
@@ -238,31 +238,43 @@ func (c *Client) Subscribe(ctx context.Context, org string, featuresAndPlans ...
 	return err
 }
 
+// Checkout creates a new checkout link for the provided org and features, if
+// any; otherwise, if no features are specified, and payment setup link is
+// returned instead.
+func (c *Client) Checkout(ctx context.Context, org string, successURL string, p *CheckoutParams) (*apitypes.CheckoutResponse, error) {
+	if p == nil {
+		p = &CheckoutParams{}
+	}
+	r := &apitypes.CheckoutRequest{
+		Org:        org,
+		SuccessURL: successURL,
+		CancelURL:  p.CancelURL,
+		TrialDays:  p.TrialDays,
+		Features:   p.Features,
+	}
+	return fetch.OK[*apitypes.CheckoutResponse, *apitypes.Error](ctx, c.client(), "POST", c.baseURL("/v1/checkout"), r)
+}
+
 type Phase = apitypes.Phase
 type OrgInfo = apitypes.OrgInfo
-type CheckoutParams = apitypes.CheckoutParams
+
+type CheckoutParams struct {
+	TrialDays int
+	Features  []string
+	CancelURL string
+}
 
 type ScheduleParams struct {
-	Info     *OrgInfo
-	Phases   []Phase
-	Checkout *CheckoutParams
+	Info   *OrgInfo
+	Phases []Phase
 }
 
 func (c *Client) Schedule(ctx context.Context, org string, p *ScheduleParams) (*apitypes.ScheduleResponse, error) {
 	return fetch.OK[*apitypes.ScheduleResponse, *apitypes.Error](ctx, c.client(), "POST", c.baseURL("/v1/subscribe"), &apitypes.ScheduleRequest{
-		Org:      org,
-		Info:     (*apitypes.OrgInfo)(p.Info),
-		Phases:   copyPhases(p.Phases),
-		Checkout: p.Checkout,
+		Org:    org,
+		Info:   (*apitypes.OrgInfo)(p.Info),
+		Phases: p.Phases,
 	})
-}
-
-func copyPhases(phases []Phase) []apitypes.Phase {
-	c := make([]apitypes.Phase, len(phases))
-	for i, p := range phases {
-		c[i] = apitypes.Phase(p)
-	}
-	return c
 }
 
 func (c *Client) WhoAmI(ctx context.Context) (apitypes.WhoAmIResponse, error) {

--- a/cmd/tier/accounts.go
+++ b/cmd/tier/accounts.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"os"
@@ -67,6 +69,7 @@ func preallocateAccount() error {
 
 func createSwitchAccount(ctx context.Context, sc *stripe.Client) (stripe.Account, error) {
 	return stripe.CreateAccount(ctx, sc, &stripe.AccountParams{
+		BusinessName: randomString("tier.switch."),
 		Meta: stripe.Meta{
 			"tier.account": "switch",
 		},
@@ -121,4 +124,14 @@ func cachePath(parts ...string) (string, error) {
 		return "", err
 	}
 	return path, nil
+}
+
+// randomString returns a random 16 byte hexencoded string with the given
+// prefix.
+func randomString(prefix string) string {
+	s := make([]byte, 16)
+	if _, err := rand.Read(s); err != nil {
+		panic(err)
+	}
+	return prefix + hex.EncodeToString(s)
 }

--- a/cmd/tier/help.go
+++ b/cmd/tier/help.go
@@ -136,17 +136,19 @@ Flags:
 
 	--email
 		set the org's email address
-	--trial days
-		set the org's trial period to the provided number of days. If
-		negative, the tial period will last indefinitely, and no other
-		phase will come after it.
 	--cancel
 		cancel the org's subscription. It is an error to provide a plan
 		or featurePlan with this flag.
+
+Checkout only flags:
 	--checkout=<success_url>
 		subscribe the org to plans and features using Stripe Checkout.
 		The success url is required, and may be used with the
 		--cancel_url flag.
+	--trial days
+		set the org's trial period to the provided number of days. If
+		negative, the tial period will last indefinitely, and no other
+		phase will come after it.
 	--cancel_url=<cancel_url>
 		specify a cancel_url for Stripe Checkout. This flag is ignored
 		if --checkout is not set.

--- a/cmd/tier/help.go
+++ b/cmd/tier/help.go
@@ -143,6 +143,13 @@ Flags:
 	--cancel
 		cancel the org's subscription. It is an error to provide a plan
 		or featurePlan with this flag.
+	--checkout=<success_url>
+		subscribe the org to plans and features using Stripe Checkout.
+		The success url is required, and may be used with the
+		--cancel_url flag.
+	--cancel_url=<cancel_url>
+		specify a cancel_url for Stripe Checkout. This flag is ignored
+		if --checkout is not set.
 
 Global Flags:
 

--- a/refs/refs.go
+++ b/refs/refs.go
@@ -209,6 +209,14 @@ func ByName(a, b FeaturePlan) bool {
 	return a.name < b.name
 }
 
+func FeaturePlanNames(fps []FeaturePlan) []string {
+	s := make([]string, len(fps))
+	for i := range fps {
+		s[i] = fps[i].String()
+	}
+	return s
+}
+
 func (fp *FeaturePlan) UnmarshalJSON(b []byte) error {
 	return unmarshal(fp, ParseFeaturePlan, b)
 }

--- a/stripe/account.go
+++ b/stripe/account.go
@@ -17,8 +17,9 @@ type Account struct {
 }
 
 type AccountParams struct {
-	Type string // default is "standard"
-	Meta Meta   // optional metadata to associate with the account
+	Type         string // default is "standard"
+	Meta         Meta   // optional metadata to associate with the account
+	BusinessName string // required for switch accounts
 }
 
 var (
@@ -31,6 +32,7 @@ func CreateAccount(ctx context.Context, c *Client, p *AccountParams) (Account, e
 		p = &AccountParams{}
 	}
 	var f Form
+	f.Set("business_profile", "name", p.BusinessName)
 	if p.Type == "" {
 		f.Set("type", "standard")
 	} else {


### PR DESCRIPTION
This commit adds Tier flare to Stripe's Checkout features. Unlike using
Stripe Checkout directly, Tier will suppress duplicate subscriptions,
and allow clients to address Customers and Prices using Tier Org and
Plan/Feature names, respectively, which allow clients to "bring your
own" IDs.

This commit also adds a new --checkout flag to the subscribe command,
generating a Stripe Checkout link via the Tier API. It also
adds an optional --cancel_url flag for specifying the URL to
send the user if they back out of the checkout session.
