### PR TITLE
control: return pseudo phases if no schedule

### DIFF
--- a/control/client.go
+++ b/control/client.go
@@ -52,6 +52,9 @@ var (
 )
 
 func FeaturePlans(fs []Feature) []refs.FeaturePlan {
+	if fs == nil {
+		return nil // preserve nil
+	}
 	ns := make([]refs.FeaturePlan, len(fs))
 	for i, f := range fs {
 		ns[i] = f.FeaturePlan

--- a/control/usage.go
+++ b/control/usage.go
@@ -47,8 +47,6 @@ func (c *Client) ReportUsage(ctx context.Context, org string, feature refs.Name,
 		f.Set("action", "increment")
 	}
 
-	// TODO(bmizerany): take idempotency key from context or use random
-	// string. if in context then upstream client supplied their own.
 	f.SetIdempotencyKey(randomString())
 
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/kr/pretty v0.3.0
-	github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f
+	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f h1:n4r/sJ92cBSBHK8n9lR1XLFr0OiTVeGfN5TR+9LaN7E=
-github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
+github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a h1:SJy1Pu0eH1C29XwJucQo73FrleVK6t4kYz4NVhp34Yw=
+github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
This prevents lookupPhases from passing empty schedule IDs to Stripe,
which causes an API error that bubbles up to Tier clients.

The lookupPhases method will now return pseudo Phases in place of
schedule phases if no schedule exists for a subscription at the time of
calling. If trialing, the first phase will be the trial phase. If a
cancel is scheduled, a final "cancel" phase will be appended after the
paid phase, if any.

This allows callers to think in Phases/Schedules only and not
worry about what a subscription is as well.

Fixes #221 
