### PR TITLE
api: accept payment on schedule

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -229,6 +229,27 @@ func TestAPISubscribe(t *testing.T) {
 		Code:    "TERR1020",
 		Message: "feature or plan not found",
 	})
+
+	_, err := tc.Schedule(ctx, "org:test", &tier.ScheduleParams{
+		Phases: []apitypes.Phase{
+			{Trial: true, Features: []string{"plan:test@0"}},
+		},
+		PaymentMethodID: "pm_card_us",
+	})
+
+	// Quick lint check to make sure the PaymentMethod made it to Stripe.
+	// In production, payment methods can be set on a sub by sub basis;
+	// however in test mode, we may only use test payment methods, and in
+	// test mode, stripe does not accept test payment methods on a sub by
+	// sub basis, so there is no real way to test our support for this
+	// feature. Instead, here, we just check stripe complains about the
+	// payment method to show it saw what we wanted it to see in
+	// production.
+	diff.Test(t, t.Errorf, err, &apitypes.Error{
+		Status:  400,
+		Code:    "invalid_payment_method",
+		Message: "No such PaymentMethod: 'pm_card_us'",
+	})
 }
 
 func TestPhaseBadOrg(t *testing.T) {

--- a/api/apitypes/apitypes.go
+++ b/api/apitypes/apitypes.go
@@ -56,9 +56,10 @@ type CheckoutRequest struct {
 }
 
 type ScheduleRequest struct {
-	Org    string   `json:"org"`
-	Info   *OrgInfo `json:"info"`
-	Phases []Phase  `json:"phases"`
+	Org             string   `json:"org"`
+	PaymentMethodID string   `json:"payment_method_id"`
+	Info            *OrgInfo `json:"info"`
+	Phases          []Phase  `json:"phases"`
 }
 
 // ScheduleResponse is the expected response from a schedule request. It is

--- a/client/tier/client.go
+++ b/client/tier/client.go
@@ -271,15 +271,17 @@ type CheckoutParams struct {
 }
 
 type ScheduleParams struct {
-	Info   *OrgInfo
-	Phases []Phase
+	Info            *OrgInfo
+	Phases          []Phase
+	PaymentMethodID string
 }
 
 func (c *Client) Schedule(ctx context.Context, org string, p *ScheduleParams) (*apitypes.ScheduleResponse, error) {
 	return fetchOK[*apitypes.ScheduleResponse, *apitypes.Error](ctx, c, "POST", "/v1/subscribe", &apitypes.ScheduleRequest{
-		Org:    org,
-		Info:   (*apitypes.OrgInfo)(p.Info),
-		Phases: p.Phases,
+		Org:             org,
+		Info:            (*apitypes.OrgInfo)(p.Info),
+		Phases:          p.Phases,
+		PaymentMethodID: p.PaymentMethodID,
 	})
 
 }

--- a/cmd/tier/help.go
+++ b/cmd/tier/help.go
@@ -152,6 +152,9 @@ Checkout only flags:
 	--cancel_url=<cancel_url>
 		specify a cancel_url for Stripe Checkout. This flag is ignored
 		if --checkout is not set.
+	--paymentmethod=<paymentmethod_id>
+		specify a payment method to use for the subscription. This flag
+		is ignored with --checkout.
 
 Global Flags:
 

--- a/cmd/tier/tier.go
+++ b/cmd/tier/tier.go
@@ -278,6 +278,7 @@ func runTier(cmd string, args []string) (err error) {
 		successURL := fs.String("checkout", "", "subscribe via Stripe checkout")
 		cancelURL := fs.String("cancel_url", "", "sets the cancel URL for use with -checkout")
 		requireBillingAddress := fs.Bool("require_billing_address", false, "require billing address for use with --checkout")
+		paymentMethod := fs.String("paymentmethod", "", "sets the Stripe payment method for the subscription (e.g. pm_123). It is ignored with --checkout")
 		if err := fs.Parse(args); err != nil {
 			return err
 		}
@@ -317,6 +318,7 @@ func runTier(cmd string, args []string) (err error) {
 				Info: &tier.OrgInfo{
 					Email: *email,
 				},
+				PaymentMethodID: *paymentMethod,
 			}
 			switch {
 			case *trial > 0:


### PR DESCRIPTION
This changes scheduling such that clients may specify payment methods
other than the default payment method for a customer. It is now the
recommended way for associating payment methods with a schedule.

In a future commit, support for listing payment methods via the Tier API
will be added.
