### PR TITLE
api: add support for decimal unit prices

### DIFF
--- a/api/apitypes/model.go
+++ b/api/apitypes/model.go
@@ -48,12 +48,12 @@ func (t *Tier) UnmarshalJSON(data []byte) error {
 }
 
 type Feature struct {
-	Title     string `json:"title,omitempty"`
-	Base      int    `json:"base,omitempty"`
-	Mode      string `json:"mode,omitempty"`
-	Aggregate string `json:"aggregate,omitempty"`
-	Tiers     []Tier `json:"tiers,omitempty"`
-	PermLink  string `json:"permLink,omitempty"`
+	Title     string  `json:"title,omitempty"`
+	Base      float64 `json:"base,omitempty"`
+	Mode      string  `json:"mode,omitempty"`
+	Aggregate string  `json:"aggregate,omitempty"`
+	Tiers     []Tier  `json:"tiers,omitempty"`
+	PermLink  string  `json:"permLink,omitempty"`
 }
 
 type Plan struct {

--- a/cmd/tier/tier.go
+++ b/cmd/tier/tier.go
@@ -257,7 +257,7 @@ func runTier(cmd string, args []string) (err error) {
 
 		for plan, p := range m.Plans {
 			for feature, f := range p.Features {
-				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\n",
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%f\n",
 					plan,
 					feature,
 					f.Mode,

--- a/control/client.go
+++ b/control/client.go
@@ -82,7 +82,7 @@ type Feature struct {
 
 	// Base is the base price for the feature. If Tiers is not empty, then Base
 	// is ignored.
-	Base int
+	Base float64
 
 	// Mode specifies the billing mode for use with Tiers.
 	//
@@ -280,7 +280,7 @@ func (c *Client) pushFeature(ctx context.Context, f Feature) (providerID string,
 	if len(f.Tiers) == 0 {
 		data.Set("recurring", "usage_type", "licensed")
 		data.Set("billing_scheme", "per_unit")
-		data.Set("unit_amount", f.Base)
+		data.Set("unit_amount_decimal", f.Base)
 	} else {
 		data.Set("recurring", "usage_type", "metered")
 		data.Set("billing_scheme", "tiered")
@@ -336,9 +336,9 @@ type stripePrice struct {
 		UsageType      string `json:"usage_type"`
 		AggregateUsage string `json:"aggregate_usage"`
 	}
-	BillingScheme string `json:"billing_scheme"`
-	TiersMode     string `json:"tiers_mode"`
-	UnitAmount    int    `json:"unit_amount"`
+	BillingScheme string  `json:"billing_scheme"`
+	TiersMode     string  `json:"tiers_mode"`
+	UnitAmount    float64 `json:"unit_amount_decimal,string"`
 	Tiers         []struct {
 		Upto         int     `json:"up_to"`
 		Price        float64 `json:"unit_amount"`

--- a/control/client_test.go
+++ b/control/client_test.go
@@ -43,6 +43,12 @@ func TestRoundTrip(t *testing.T) {
 
 	want := []Feature{
 		{
+			FeaturePlan: refs.MustParseFeaturePlan("feature:decimal@fractionalBase"),
+			Interval:    "@daily",
+			Currency:    "eur",
+			Base:        0.1,
+		},
+		{
 			FeaturePlan: refs.MustParseFeaturePlan("feature:test@plan:free@3"),
 			Interval:    "@daily",
 			Currency:    "eur",
@@ -63,6 +69,12 @@ func TestRoundTrip(t *testing.T) {
 				{Upto: 3, Price: 300, Base: 3},
 			},
 		},
+	}
+
+	if !slices.IsSortedFunc(want, func(a, b Feature) bool {
+		return a.Less(b.FeaturePlan)
+	}) {
+		t.Fatal("want must be sorted")
 	}
 
 	if err := tc.Push(ctx, want, pushLogger(t)); err != nil {


### PR DESCRIPTION
This commit adds support for fractional unit amounts for the base price
of a licensed feature.

Closes #223