### PR TITLE
stripe: fix test mode links

### DIFF
--- a/cmd/tier/tier_test.go
+++ b/cmd/tier/tier_test.go
@@ -305,7 +305,7 @@ func TestPushLinks(t *testing.T) {
 	    }
 	}`)
 	tt.Run("push", "-")
-	tt.GrepStdout("https://dashboard.stripe.com/acct_state/prices/price_123", "expected URL")
+	tt.GrepStdout("https://dashboard.stripe.com/acct_state/test/prices/price_123", "expected URL")
 
 	// get out of isolation
 	if err := os.Remove("tier.state"); err != nil {
@@ -323,7 +323,7 @@ func TestPushLinks(t *testing.T) {
 	    }
 	}`)
 	tt.Run("push", "-")
-	tt.GrepStdout("https://dashboard.stripe.com/acct_profile/prices/price_123", "expected URL")
+	tt.GrepStdout("https://dashboard.stripe.com/acct_profile/test/prices/price_123", "expected URL")
 
 	// assume default dashboard URL is okay if STRIPE_API_KEY is set
 	tt.SetStdinString(`{

--- a/stripe/client.go
+++ b/stripe/client.go
@@ -46,13 +46,17 @@ func MakeID(parts ...string) string {
 // If live is true, a link to the live dashboard is returned, otherwise a test
 // link is returned.
 func Link(live bool, accountID string, parts ...string) (string, error) {
-	var base string
-	if !live && accountID == "" {
-		base = "https://dashboard.stripe.com/test"
-	} else {
-		base = "https://dashboard.stripe.com"
+	base, err := url.JoinPath("https://dashboard.stripe.com", accountID)
+	if err != nil {
+		return "", err
 	}
-	return url.JoinPath(base, append([]string{accountID}, parts...)...)
+	if !live {
+		base, err = url.JoinPath(base, "test")
+		if err != nil {
+			return "", err
+		}
+	}
+	return url.JoinPath(base, parts...)
 }
 
 type Error struct {

--- a/stripe/client_test.go
+++ b/stripe/client_test.go
@@ -27,7 +27,7 @@ func TestLink(t *testing.T) {
 	}{
 		{true, "acct_123", "foo", "https://dashboard.stripe.com/acct_123/foo"},
 		{true, "", "foo", "https://dashboard.stripe.com/foo"},
-		{false, "acct_123", "foo", "https://dashboard.stripe.com/acct_123/foo"},
+		{false, "acct_123", "foo", "https://dashboard.stripe.com/acct_123/test/foo"},
 		{false, "", "foo", "https://dashboard.stripe.com/test/foo"},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Previously Link handled the case of a blank account incorrectly, assuming it was "live" when the key was test.

Closes: #244