### PR TITLE
control: convert single tier to metered+per_unit

### DIFF
--- a/control/schedule_test.go
+++ b/control/schedule_test.go
@@ -302,7 +302,6 @@ func TestScheduleFreeTrials(t *testing.T) {
 	s.checkInvoices("org:paid", []Invoice{{
 		Lines: []InvoiceLineItem{
 			lineItem(featureX, 2, 2),
-			zero,
 		},
 		SubtotalPreTax: 2,
 		Subtotal:       2,


### PR DESCRIPTION
This changes how Tier interprets and converts tiers to Stripe prices.

Previously, a single tier in a pricing.json would convert to a metered
price with one or two tiers depending on if the tier had an inf limit or
not. If it did not have an inf limit, a catch-all was created to satisfy
Stripe. This produced awkward invoices.

This commit changes Tier to convert a feature that has a single tier
without a base price to be a metered+per_unit price in Stripe, which
shows up less awkwardly on invoices.

This also opens us up to support pricing transforms in Stripe for these
types of prices.
