### PR TITLE
control: support division transform

### DIFF
--- a/api/apitypes/model.go
+++ b/api/apitypes/model.go
@@ -47,13 +47,18 @@ func (t *Tier) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+type Divide struct {
+	By       int    `json:"by,omitempty"`
+	Rounding string `json:"rounding,omitempty"`
+}
+
 type Feature struct {
 	Title     string  `json:"title,omitempty"`
 	Base      float64 `json:"base,omitempty"`
 	Mode      string  `json:"mode,omitempty"`
 	Aggregate string  `json:"aggregate,omitempty"`
 	Tiers     []Tier  `json:"tiers,omitempty"`
-	PermLink  string  `json:"permLink,omitempty"`
+	Divide    *Divide `json:"divide,omitempty"`
 }
 
 type Plan struct {

--- a/api/materialize/views_test.go
+++ b/api/materialize/views_test.go
@@ -36,6 +36,9 @@ func TestPricingHuJSON(t *testing.T) {
 					"feature:base": {
 						"base": 100,
 					},
+					"feature:xform": {
+						"divide": {"by": 100, "rounding": "up"},
+					}
 				},
 			},
 		}
@@ -74,6 +77,17 @@ func TestPricingHuJSON(t *testing.T) {
 				{Upto: tier.Inf, Price: 50, Base: 0},
 			},
 		},
+		{
+			PlanTitle:            "Just an example plan to show off features part duex",
+			Title:                "feature:xform@plan:example@2",
+			FeaturePlan:          refs.MustParseFeaturePlan("feature:xform@plan:example@2"),
+			Currency:             "usd",
+			Interval:             "@monthly",
+			Mode:                 "graduated", // defaults
+			Aggregate:            "sum",
+			TransformDenominator: 100,
+			TransformRoundUp:     true,
+		},
 	}
 
 	diff.Test(t, t.Errorf, got, want)
@@ -104,6 +118,9 @@ func TestPricingHuJSON(t *testing.T) {
 				"features": {
 					"feature:base": {
 						"base": 100,
+					},
+					"feature:xform": {
+						"divide": {"by": 100, "rounding": "up"},
 					}
 				}
 			}

--- a/control/client_test.go
+++ b/control/client_test.go
@@ -72,6 +72,9 @@ func TestRoundTrip(t *testing.T) {
 			// tiers_mode isn't needed or even set
 			Mode: "",
 
+			TransformDenominator: 100,
+			TransformRoundUp:     true,
+
 			Aggregate: "perpetual",
 			Tiers: []Tier{
 				{Upto: 1, Price: 100, Base: 0},


### PR DESCRIPTION
This commit adds support for transforming the quantities of per unit
prices using division and rounding.

A new 'divide' field and object is ready for use in pricing.json, like:

  plans["plan:pro@0"].features["feature:builds"].divide.by = 100

Rounding down is the default rounding behavior. To override, use:

  plans["plan:pro@0"].features["feature:builds"].divide.rounding = "up"
