### PR TITLE
api: support automatic tax collection

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -249,9 +249,10 @@ func (h *Handler) serveSubscribe(w http.ResponseWriter, r *http.Request) error {
 				return err
 			}
 			phases = append(phases, control.Phase{
-				Trial:     p.Trial,
-				Effective: p.Effective,
-				Features:  fs,
+				Trial:        p.Trial,
+				Effective:    p.Effective,
+				Features:     fs,
+				AutomaticTax: sr.Tax.Automatic,
 			})
 		}
 	}
@@ -341,6 +342,9 @@ func (h *Handler) servePhase(w http.ResponseWriter, r *http.Request) error {
 				Plans:     p.Plans,
 				Fragments: p.Fragments(),
 				Trial:     p.Trial,
+				Tax: apitypes.Taxation{
+					Automatic: p.AutomaticTax,
+				},
 			})
 		}
 	}

--- a/api/apitypes/apitypes.go
+++ b/api/apitypes/apitypes.go
@@ -26,6 +26,10 @@ type Phase struct {
 	Features  []string  `json:"features,omitempty"`
 }
 
+type Taxation struct {
+	Automatic bool `json:"automatic,omitempty"`
+}
+
 type PhaseResponse struct {
 	Effective time.Time          `json:"effective,omitempty"`
 	End       time.Time          `json:"end,omitempty"`
@@ -33,6 +37,7 @@ type PhaseResponse struct {
 	Plans     []refs.Plan        `json:"plans,omitempty"`
 	Fragments []refs.FeaturePlan `json:"fragments,omitempty"`
 	Trial     bool               `json:"trial,omitempty"`
+	Tax       Taxation           `json:"tax,omitempty"`
 }
 
 func (pr PhaseResponse) MarshalJSON() ([]byte, error) {
@@ -90,6 +95,7 @@ type ScheduleRequest struct {
 	PaymentMethodID string   `json:"payment_method_id"`
 	Info            *OrgInfo `json:"info"`
 	Phases          []Phase  `json:"phases"`
+	Tax             Taxation `json:"tax"`
 }
 
 // ScheduleResponse is the expected response from a schedule request. It is

--- a/api/apitypes/json_test.go
+++ b/api/apitypes/json_test.go
@@ -13,13 +13,13 @@ func TestPhaseResponseJSON(t *testing.T) {
 	}{
 		{
 			pr:   PhaseResponse{},
-			want: `{"effective":"0001-01-01T00:00:00Z"}`,
+			want: `{"effective":"0001-01-01T00:00:00Z","tax":{}}`,
 		},
 		{
 			pr: PhaseResponse{
 				End: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
-			want: `{"effective":"0001-01-01T00:00:00Z","end":"2018-01-01T00:00:00Z"}`,
+			want: `{"effective":"0001-01-01T00:00:00Z","tax":{},"end":"2018-01-01T00:00:00Z"}`,
 		},
 	}
 

--- a/client/tier/client.go
+++ b/client/tier/client.go
@@ -305,10 +305,14 @@ type CheckoutParams struct {
 	RequireBillingAddress bool
 }
 
+type Taxation = apitypes.Taxation
+
 type ScheduleParams struct {
 	Info            *OrgInfo
 	Phases          []Phase
 	PaymentMethodID string
+
+	Tax Taxation
 }
 
 func (c *Client) Schedule(ctx context.Context, org string, p *ScheduleParams) (*apitypes.ScheduleResponse, error) {
@@ -317,6 +321,7 @@ func (c *Client) Schedule(ctx context.Context, org string, p *ScheduleParams) (*
 		Info:            (*apitypes.OrgInfo)(p.Info),
 		Phases:          p.Phases,
 		PaymentMethodID: p.PaymentMethodID,
+		Tax:             p.Tax,
 	})
 
 }

--- a/cmd/tier/tier.go
+++ b/cmd/tier/tier.go
@@ -279,6 +279,7 @@ func runTier(cmd string, args []string) (err error) {
 		cancelURL := fs.String("cancel_url", "", "sets the cancel URL for use with -checkout")
 		requireBillingAddress := fs.Bool("require_billing_address", false, "require billing address for use with --checkout")
 		paymentMethod := fs.String("paymentmethod", "", "sets the Stripe payment method for the subscription (e.g. pm_123). It is ignored with --checkout")
+		tax := fs.String("tax", "", "sets the Stripe tax rate for the subscription ('auto' is currently the only supported value)")
 		if err := fs.Parse(args); err != nil {
 			return err
 		}
@@ -290,6 +291,10 @@ func runTier(cmd string, args []string) (err error) {
 		// the cancel must be used without arguments
 		if *cancel && fs.NArg() > 1 {
 			fmt.Fprintln(stderr, "tier: the -cancel flag must be used without arguments")
+			return errUsage
+		}
+		if *tax != "" && *tax != "auto" {
+			fmt.Fprintf(stderr, "tier: invalid tax rate %q\n", *tax)
 			return errUsage
 		}
 
@@ -319,6 +324,7 @@ func runTier(cmd string, args []string) (err error) {
 					Email: *email,
 				},
 				PaymentMethodID: *paymentMethod,
+				Tax:             tier.Taxation{Automatic: *tax == "auto"},
 			}
 			switch {
 			case *trial > 0:

--- a/types/they/want.go
+++ b/types/they/want.go
@@ -1,0 +1,17 @@
+// Package wants provides utilities learning what HTTP clients want.
+package they
+
+import (
+	"net/http"
+	"regexp"
+)
+
+// A reports whether the request is for the given method and pattern. The
+// provided pattern is automatically anchored at both ends.
+//
+// It panics if the pattern is not a valid regular expression.
+func Want(r *http.Request, method, pattern string) bool {
+	// TODO(bmizerany): memoize the regexp
+	exp := regexp.MustCompile("^" + pattern + "$")
+	return r.Method == method && exp.MatchString(r.URL.Path)
+}


### PR DESCRIPTION
This adds support for Stripe's automatic tax collection. Clients may now
set tax.automatic to true on /v1/subscribe to ensure Stripe collects
taxes on total spend.
