### PR TITLE
client/tier: change baseURL if TIER_API_KEY set

### DIFF
--- a/client/tier/client.go
+++ b/client/tier/client.go
@@ -62,8 +62,12 @@ func clockFromContext(ctx context.Context) string {
 // invalid URL.
 func FromEnv() (*Client, error) {
 	key := os.Getenv("TIER_API_KEY")
-
 	baseURL := os.Getenv("TIER_BASE_URL")
+	if key != "" {
+		if baseURL == "" {
+			baseURL = "https://api.tier.run"
+		}
+	}
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}

--- a/client/tier/client_test.go
+++ b/client/tier/client_test.go
@@ -42,6 +42,57 @@ func TestUserPassword(t *testing.T) {
 	diff.Test(t, t.Errorf, got, want)
 }
 
+func TestFromEnv(t *testing.T) {
+	cases := []struct {
+		envBaseURL  string
+		envAPIKey   string
+		wantBaseURL string
+		wantAPIKey  string
+	}{
+		{
+			envBaseURL:  "https://x.com",
+			envAPIKey:   "testKey",
+			wantBaseURL: "https://x.com",
+			wantAPIKey:  "testKey",
+		},
+		{
+			envBaseURL:  "",
+			envAPIKey:   "testKey",
+			wantBaseURL: "https://api.tier.run",
+			wantAPIKey:  "testKey",
+		},
+		{
+			envBaseURL:  "",
+			envAPIKey:   "",
+			wantBaseURL: defaultBaseURL,
+			wantAPIKey:  "",
+		},
+		{
+			envBaseURL:  "https://y.com",
+			envAPIKey:   "",
+			wantBaseURL: "https://y.com",
+			wantAPIKey:  "",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run("", func(t *testing.T) {
+			t.Setenv("TIER_BASE_URL", tt.envBaseURL)
+			t.Setenv("TIER_API_KEY", tt.envAPIKey)
+			c, err := FromEnv()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if c.BaseURL != tt.wantBaseURL {
+				t.Errorf("BaseURL = %q; want %q", c.BaseURL, tt.wantBaseURL)
+			}
+			if c.APIKey != tt.wantAPIKey {
+				t.Errorf("APIKey = %q; want %q", c.APIKey, tt.wantAPIKey)
+			}
+		})
+	}
+}
+
 func TestReportNow(t *testing.T) {
 	var mu sync.Mutex
 	var got []apitypes.ReportRequest


### PR DESCRIPTION
This commit changes FromEnv to set BaseURL to https://api.tier.run if a
TIER_API_KEY is present in the environment, and TIER_BASE_URL is unset.

Fixes TIE-177
