### PR TITLE
api: add `/v1/phases` with coupon information

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -181,6 +181,8 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request) error {
 		return h.serveSubscribe(w, r)
 	case "/v1/checkout":
 		return h.serveCheckout(w, r)
+	case "/v1/phases":
+		return h.servePhases(w, r)
 	case "/v1/phase":
 		return h.servePhase(w, r)
 	case "/v1/pull":
@@ -321,6 +323,41 @@ func (h *Handler) serveWhoAmI(w http.ResponseWriter, r *http.Request) error {
 		Isolated:   who.Isolated,
 		URL:        who.URL(),
 	})
+}
+
+func (h *Handler) servePhases(w http.ResponseWriter, r *http.Request) error {
+	org := r.FormValue("org")
+	s, err := h.c.LookupPhases(r.Context(), org)
+	if err != nil {
+		return err
+	}
+
+	var pr apitypes.PhasesResponse
+	ps := s.Phases
+	for i, p := range ps {
+		if p.Current {
+			pr.Current = apitypes.Period(s.Current)
+		}
+		var end time.Time
+		if i+1 < len(ps) {
+			end = ps[i+1].Effective
+		}
+		pr.Phases = append(pr.Phases, apitypes.PhaseResponse{
+			Effective: p.Effective,
+			End:       end,
+			Features:  p.Features,
+			Plans:     p.Plans,
+			Fragments: p.Fragments(),
+			Trial:     p.Trial,
+			Tax: apitypes.Taxation{
+				Automatic: p.AutomaticTax,
+			},
+			Current: apitypes.Period(s.Current),
+			Coupon:  p.Coupon,
+		})
+	}
+
+	return httpJSON(w, pr)
 }
 
 func (h *Handler) servePhase(w http.ResponseWriter, r *http.Request) error {

--- a/api/api.go
+++ b/api/api.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kr/pretty"
 	"golang.org/x/exp/slices"
 	"tier.run/api/apitypes"
 	"tier.run/api/materialize"
@@ -325,6 +324,7 @@ func (h *Handler) serveWhoAmI(w http.ResponseWriter, r *http.Request) error {
 	})
 }
 
+// EXPERIMENTAL (undocumented)
 func (h *Handler) servePhases(w http.ResponseWriter, r *http.Request) error {
 	org := r.FormValue("org")
 	s, err := h.c.LookupPhases(r.Context(), org)
@@ -352,8 +352,9 @@ func (h *Handler) servePhases(w http.ResponseWriter, r *http.Request) error {
 			Tax: apitypes.Taxation{
 				Automatic: p.AutomaticTax,
 			},
-			Current: apitypes.Period(s.Current),
-			Coupon:  p.Coupon,
+			Current:    apitypes.Period(s.Current),
+			Coupon:     p.Coupon,
+			CouponData: (*apitypes.Coupon)(p.CouponData),
 		})
 	}
 
@@ -368,8 +369,6 @@ func (h *Handler) servePhase(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	ps := s.Phases
-	h.Logf("lookup phases: %# v", pretty.Formatter(ps))
-
 	for i, p := range ps {
 		if p.Current {
 			var end time.Time
@@ -386,8 +385,9 @@ func (h *Handler) servePhase(w http.ResponseWriter, r *http.Request) error {
 				Tax: apitypes.Taxation{
 					Automatic: p.AutomaticTax,
 				},
-				Current: apitypes.Period(s.Current),
-				Coupon:  p.Coupon,
+				Current:    apitypes.Period(s.Current),
+				Coupon:     p.Coupon,
+				CouponData: (*apitypes.Coupon)(p.CouponData),
 			})
 		}
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -447,6 +447,9 @@ func TestPhase(t *testing.T) {
 				Trial:    true,
 				Features: []string{"plan:test@0"},
 				Coupon:   "coupon_test",
+				CouponData: &apitypes.Coupon{
+					ID: "coupon_test",
+				},
 			}, {
 				Effective: now.AddDate(0, 0, 14),
 				Trial:     false,
@@ -459,6 +462,9 @@ func TestPhase(t *testing.T) {
 				Plans:     mpps("plan:test@0"),
 				Trial:     true,
 				Coupon:    "coupon_test",
+				CouponData: &apitypes.Coupon{
+					ID: "coupon_test",
+				},
 			},
 		},
 		{
@@ -508,7 +514,7 @@ func TestPhase(t *testing.T) {
 			}
 
 			got.Current = apitypes.Period{}
-			diff.Test(t, t.Errorf, got, tt.want)
+			diff.Test(t, t.Errorf, got, tt.want, diff.KeepFields[apitypes.Coupon]("ID"))
 		})
 	}
 }

--- a/api/apitypes/apitypes.go
+++ b/api/apitypes/apitypes.go
@@ -20,11 +20,28 @@ func (e *Error) Error() string {
 		e.Status, e.Code, e.Message)
 }
 
+type Coupon struct {
+	ID               string `json:"id"`
+	Metadata         map[string]string
+	Created          time.Time
+	AmountOff        int     `json:"amount_off"`
+	Currency         string  `json:"currency"`
+	Duration         string  `json:"duration"`
+	DurationInMonths int     `json:"duration_in_months"`
+	MaxRedemptions   int     `json:"max_redemptions"`
+	Name             string  `json:"name"`
+	PercentOff       float64 `json:"percent_off"`
+	RedeemBy         time.Time
+	TimesRedeemed    int  `json:"times_redeemed"`
+	Valid            bool `json:"valid"`
+}
+
 type Phase struct {
-	Trial     bool      `json:"trial,omitempty"`
-	Effective time.Time `json:"effective,omitempty"`
-	Features  []string  `json:"features,omitempty"`
-	Coupon    string    `json:"coupon,omitempty"`
+	Trial      bool      `json:"trial,omitempty"`
+	Effective  time.Time `json:"effective,omitempty"`
+	Features   []string  `json:"features,omitempty"`
+	Coupon     string    `json:"coupon,omitempty"`
+	CouponData *Coupon   `json:"coupon_data,omitempty"`
 }
 
 type Taxation struct {
@@ -41,16 +58,25 @@ func (p *Period) IsZero() bool {
 	return p.Effective.IsZero() && p.End.IsZero()
 }
 
+type PhasesResponse struct {
+	Current Period          `json:"current,omitempty"`
+	Phases  []PhaseResponse `json:"phases"`
+}
+
+// The PhaseResponse is a response with all current phase fields exposed as
+// top-level fields. Clients that need all phase data should use the Phases
+// field.
 type PhaseResponse struct {
-	Effective time.Time          `json:"effective,omitempty"`
-	End       time.Time          `json:"end,omitempty"`
-	Features  []refs.FeaturePlan `json:"features,omitempty"`
-	Plans     []refs.Plan        `json:"plans,omitempty"`
-	Fragments []refs.FeaturePlan `json:"fragments,omitempty"`
-	Trial     bool               `json:"trial,omitempty"`
-	Tax       Taxation           `json:"tax,omitempty"`
-	Current   Period             `json:"current,omitempty"`
-	Coupon    string             `json:"coupon,omitempty"`
+	Effective  time.Time          `json:"effective,omitempty"`
+	End        time.Time          `json:"end,omitempty"`
+	Features   []refs.FeaturePlan `json:"features,omitempty"`
+	Plans      []refs.Plan        `json:"plans,omitempty"`
+	Fragments  []refs.FeaturePlan `json:"fragments,omitempty"`
+	Trial      bool               `json:"trial,omitempty"`
+	Tax        Taxation           `json:"tax,omitempty"`
+	Current    Period             `json:"current,omitempty"` // not set on PhasesResponse
+	Coupon     string             `json:"coupon,omitempty"`
+	CouponData *Coupon            `json:"coupon_data,omitempty"`
 }
 
 func (pr PhaseResponse) MarshalJSON() ([]byte, error) {

--- a/api/apitypes/apitypes.go
+++ b/api/apitypes/apitypes.go
@@ -24,16 +24,16 @@ type Coupon struct {
 	ID               string `json:"id"`
 	Metadata         map[string]string
 	Created          time.Time
-	AmountOff        int     `json:"amount_off"`
-	Currency         string  `json:"currency"`
-	Duration         string  `json:"duration"`
-	DurationInMonths int     `json:"duration_in_months"`
-	MaxRedemptions   int     `json:"max_redemptions"`
-	Name             string  `json:"name"`
-	PercentOff       float64 `json:"percent_off"`
+	AmountOff        int     `json:"amount_off,omitempty"`
+	Currency         string  `json:"currency,omitempty"`
+	Duration         string  `json:"duration,omitempty"`
+	DurationInMonths int     `json:"duration_in_months,omitempty"`
+	MaxRedemptions   int     `json:"max_redemptions,omitempty"`
+	Name             string  `json:"name,omitempty"`
+	PercentOff       float64 `json:"percent_off,omitempty"`
 	RedeemBy         time.Time
-	TimesRedeemed    int  `json:"times_redeemed"`
-	Valid            bool `json:"valid"`
+	TimesRedeemed    int  `json:"times_redeemed,omitempty"`
+	Valid            bool `json:"valid,omitempty"`
 }
 
 type Phase struct {

--- a/client/tier/client.go
+++ b/client/tier/client.go
@@ -128,6 +128,13 @@ func (c *Client) LookupPhase(ctx context.Context, org string) (apitypes.PhaseRes
 	return fetchOK[apitypes.PhaseResponse, *apitypes.Error](ctx, c, "GET", "/v1/phase?org="+org, nil)
 }
 
+// LookupPhases reports information about all recent, current, and future phases for org.
+//
+// EXPERIMENTAL: This API is subject to change.
+func (c *Client) LookupPhases(ctx context.Context, org string) (apitypes.PhasesResponse, error) {
+	return fetchOK[apitypes.PhasesResponse, *apitypes.Error](ctx, c, "GET", "/v1/phases?org="+org, nil)
+}
+
 // LookupLimits reports the current usage and limits for the provided org.
 func (c *Client) LookupLimits(ctx context.Context, org string) (apitypes.UsageResponse, error) {
 	return fetchOK[apitypes.UsageResponse, *apitypes.Error](ctx, c, "GET", "/v1/limits?org="+org, nil)

--- a/control/schedule.go
+++ b/control/schedule.go
@@ -296,7 +296,7 @@ type stripeSubSchedule struct {
 		Items    []struct {
 			Price stripePrice
 		}
-		Coupon string
+		Coupon stripeCoupon
 	}
 }
 
@@ -348,6 +348,7 @@ func (c *Client) lookupPhases(ctx context.Context, org string, s subscription, n
 
 	var ss stripeSubSchedule
 	var f stripe.Form
+	f.Add("expand[]", "phases.coupon")
 	f.Add("expand[]", "phases.items.price")
 	if err := c.Stripe.Do(ctx, "GET", "/v1/subscription_schedules/"+s.ScheduleID, f, &ss); err != nil {
 		return Phase{}, nil, err
@@ -385,7 +386,8 @@ func (c *Client) lookupPhases(ctx context.Context, org string, s subscription, n
 
 			AutomaticTax: s.AutomaticTax,
 
-			Coupon: p.Coupon,
+			Coupon:     p.Coupon.ID,
+			CouponData: stripeCouponToCoupon(p.Coupon),
 		}
 		all = append(all, p)
 		if p.Current {

--- a/control/schedule_test.go
+++ b/control/schedule_test.go
@@ -904,7 +904,13 @@ func TestLookupPhases(t *testing.T) {
 
 	s := newScheduleTester(t)
 	s.push(fs0)
-	s.schedule("org:example", 0, "", FeaturePlans(fs0)...)
+
+	p := ScheduleParams{
+		Phases: []Phase{{Features: FeaturePlans(fs0)}},
+	}
+	if err := s.cc.Schedule(s.ctx, "org:example", p); err != nil {
+		s.t.Fatalf("error subscribing: %v", err)
+	}
 
 	got, err := s.cc.LookupPhases(s.ctx, "org:example")
 	if err != nil {

--- a/control/schedule_test.go
+++ b/control/schedule_test.go
@@ -1150,6 +1150,48 @@ func TestLookupPhasesNoSchedule(t *testing.T) {
 		{
 			s: `
 				"start_date": 123123123,
+				"discount": {
+					"coupon": {
+						"id": "coupon:test",
+						"created": 123123123,
+						"percent_off": 50,
+						"metadata": {"test": "meta"},
+						"redeem_by": 123123123,
+						"max_redemptions": 1,
+						"times_redeemed": 1,
+						"amount_off": 1,
+						"currency": "usd",
+						"duration": "forever",
+						"duration_in_months": 1,
+					}
+				},
+			`,
+			want: []Phase{{
+				Org:       "org:test",
+				Effective: time.Unix(123123123, 0),
+				Current:   true,
+				Trial:     false,
+				Features:  fs,
+				Plans:     []refs.Plan{mpp("plan:test@0")},
+				Coupon:    "coupon:test",
+				CouponData: &Coupon{
+					ID:               "coupon:test",
+					Created:          time.Unix(123123123, 0),
+					PercentOff:       50,
+					AmountOff:        1,
+					Currency:         "usd",
+					RedeemBy:         time.Unix(123123123, 0),
+					MaxRedemptions:   1,
+					TimesRedeemed:    1,
+					Metadata:         map[string]string{"test": "meta"},
+					Duration:         "forever",
+					DurationInMonths: 1,
+				},
+			}},
+		},
+		{
+			s: `
+				"start_date": 123123123,
 				"cancel_at": 223123123,
 			`,
 			want: []Phase{{


### PR DESCRIPTION
This PR adds the new `/v1/phases` API which reports all recent, current, and future phases for an org. It also expands all coupon information.