### PR TITLE
Fix docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Tier will handle setting up and managing Stripe in a way that is much more frien
 
 
 ## Docs and Community
-- [Documentation is available here](https://docs.tier.run/)
+- [Documentation is available here](https://www.tier.run/docs)
 - Join our Slack here: [<img src="https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white" />](https://join.slack.com/t/tier-community/shared_invite/zt-1blotqjb9-wvkYMo8QkhaEWziprdjnIA)
 
 # Key Features and Capabilities


### PR DESCRIPTION
Looks like the docs subdomain doesn't exist anymore(?) and docs are at www.tier.run/docs

<img width="420" alt="image" src="https://github.com/tierrun/tier/assets/14852491/f4ee1791-efc5-43fa-9e47-40902428db08">
